### PR TITLE
Make the GitHub Pages workflow run on dev branch

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,7 +2,7 @@ name: Deploy static content to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["dev"]
 
 # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Make the Pages workflow run only on `dev`