### PR TITLE
Change the path backend docs, fix links in doc index HTML

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -49,7 +49,9 @@ jobs:
 
       - name: Copy Backend API Docs into the docs dir
         working-directory: backend
-        run: cp -r target/doc ../docs
+        run: |
+          mv target/doc target/backend
+          cp -r target/backend ../docs
 ### END BACKEND ###
 
 ### BEGIN NLP ###

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
     <h1>XMoods Documentation</h1>
     
     <h2>
-      <a href="doc/backend/index.html">Backend</a>
+      <a href="backend/xmoods_backend/index.html">Backend</a>
     </h2>
     <h2>
       <a href="frontend/index.html">Frontend</a>


### PR DESCRIPTION
Change the path to backend docs from `doc/xmoods_backend` to `backend/xmoods_backend`, since in the future there will probably be a few separate crates in the backend workspace.