### PR TITLE
Add all debug endpoints

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-
-use axum::{routing::get, Router};
-
 use crate::AppState;
+use axum::{routing::get, Router};
+use std::collections::HashMap;
 
 pub mod test;
 
-type PlainParams = HashMap<String, String>;
+type AnyParams = HashMap<String, String>;
 
 pub fn router() -> Router<AppState> {
     Router::<AppState>::new()
@@ -14,4 +12,5 @@ pub fn router() -> Router<AppState> {
         .route("/test/lorem", get(test::lorem))
         .route("/test/subreddit-info", get(test::subreddit_info))
         .route("/test/post-comments", get(test::post_comments))
+        .route("/test/user-info", get(test::user_info))
 }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -13,5 +13,5 @@ pub fn router() -> Router<AppState> {
         .route("/test/timeout", get(test::timeout))
         .route("/test/lorem", get(test::lorem))
         .route("/test/subreddit-info", get(test::subreddit_info))
-        .route("/test/subreddit-comments", get(test::subreddit_comments))
+        .route("/test/post-comments", get(test::post_comments))
 }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -14,4 +14,5 @@ pub fn router() -> Router<AppState> {
         .route("/test/post-comments", get(test::post_comments))
         .route("/test/user-info", get(test::user_info))
         .route("/test/subreddit-posts", get(test::subreddit_posts))
+        .route("/test/user-posts", get(test::user_posts))
 }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -13,4 +13,5 @@ pub fn router() -> Router<AppState> {
         .route("/test/subreddit-info", get(test::subreddit_info))
         .route("/test/post-comments", get(test::post_comments))
         .route("/test/user-info", get(test::user_info))
+        .route("/test/subreddit-posts", get(test::subreddit_posts))
 }

--- a/backend/src/api/test.rs
+++ b/backend/src/api/test.rs
@@ -137,3 +137,18 @@ pub async fn user_info(
 
     Ok(Json(info))
 }
+
+pub async fn subreddit_posts(
+    State(mut state): State<AppState>,
+    Query(params): Query<AnyParams>,
+) -> Result<Json<KindContainer>, AppError> {
+    let subreddit = params
+        .get("r")
+        .ok_or_else(|| AppError::new(StatusCode::BAD_REQUEST, "Missing `r` parameter"))?;
+    let req = RedditRequest::SubredditPosts(subreddit.into());
+    let json = state.reddit.fetch_raw(req).await?;
+
+    let info = serde_json::from_value::<KindContainer>(json).unwrap();
+
+    Ok(Json(info))
+}

--- a/backend/src/api/test.rs
+++ b/backend/src/api/test.rs
@@ -16,7 +16,7 @@ use crate::{
     AppState,
 };
 
-use super::PlainParams;
+use super::AnyParams;
 
 /// Returns after a specified delay.
 #[utoipa::path(
@@ -31,7 +31,7 @@ use super::PlainParams;
     )
 )]
 #[logfn(err = "ERROR", fmt = "'timeout' failed: {:?}")]
-pub async fn timeout(Query(params): Query<PlainParams>) -> Result<Json<Value>, AppError> {
+pub async fn timeout(Query(params): Query<AnyParams>) -> Result<Json<Value>, AppError> {
     let t = params
         .get("t")
         .ok_or_else(|| AppError::new(StatusCode::BAD_REQUEST, "Missing `t` parameter"))?
@@ -59,7 +59,7 @@ pub async fn timeout(Query(params): Query<PlainParams>) -> Result<Json<Value>, A
     )
 )]
 #[logfn(err = "ERROR", fmt = "'lorem' failed: {:?}")]
-pub async fn lorem(Query(params): Query<PlainParams>) -> Result<Json<Value>, AppError> {
+pub async fn lorem(Query(params): Query<AnyParams>) -> Result<Json<Value>, AppError> {
     let words = params
         .get("words")
         .unwrap_or(&"50".to_string())
@@ -81,7 +81,7 @@ pub async fn lorem(Query(params): Query<PlainParams>) -> Result<Json<Value>, App
 
 pub async fn subreddit_info(
     State(mut state): State<AppState>,
-    Query(params): Query<PlainParams>,
+    Query(params): Query<AnyParams>,
 ) -> Result<Json<KindContainer>, AppError> {
     let subreddit = params
         .get("r")
@@ -96,7 +96,7 @@ pub async fn subreddit_info(
 
 pub async fn post_comments(
     State(mut state): State<AppState>,
-    Query(params): Query<PlainParams>,
+    Query(params): Query<AnyParams>,
 ) -> Result<Json<Vec<KindContainer>>, AppError> {
     let r = params
         .get("r")
@@ -120,4 +120,20 @@ pub async fn post_comments(
     let elapsed = SystemTime::now().duration_since(start).unwrap();
     info!("Data parsed successfully. Took {:?}", elapsed);
     Ok(Json(val))
+}
+
+pub async fn user_info(
+    State(mut state): State<AppState>,
+    Query(params): Query<AnyParams>,
+) -> Result<Json<KindContainer>, AppError> {
+    let user = params
+        .get("u")
+        .ok_or_else(|| AppError::new(StatusCode::BAD_REQUEST, "Missing `u` parameter"))?;
+    let req = RedditRequest::UserInfo(user.into());
+    
+    let json = state.reddit.fetch_raw(req).await?;
+
+    let info = serde_json::from_value::<KindContainer>(json).unwrap();
+
+    Ok(Json(info))
 }

--- a/backend/src/api/test.rs
+++ b/backend/src/api/test.rs
@@ -152,3 +152,18 @@ pub async fn subreddit_posts(
 
     Ok(Json(info))
 }
+
+pub async fn user_posts(
+    State(mut state): State<AppState>,
+    Query(params): Query<AnyParams>,
+) -> Result<Json<KindContainer>, AppError> {
+    let user = params
+        .get("u")
+        .ok_or_else(|| AppError::new(StatusCode::BAD_REQUEST, "Missing `u` parameter"))?;
+    let req = RedditRequest::UserPosts(user.into());
+    let json = state.reddit.fetch_raw(req).await?;
+
+    let info = serde_json::from_value(json).unwrap();
+
+    Ok(Json(info))
+}

--- a/backend/src/api/test.rs
+++ b/backend/src/api/test.rs
@@ -5,20 +5,14 @@ use axum::{
     Json,
 };
 use lipsum::lipsum;
-use log::{info, warn};
+use log::info;
 use log_derive::logfn;
 use reqwest::StatusCode;
 use serde_json::{json, Value};
 
 use crate::{
     app_error::AppError,
-    reddit::{
-        model::{
-            listing::KindContainer,
-            subreddit_info::{RedditSubredditInfo, RedditSubredditInfoRaw},
-        },
-        RedditRequest,
-    },
+    reddit::{model::listing::KindContainer, RedditRequest},
     AppState,
 };
 
@@ -88,19 +82,19 @@ pub async fn lorem(Query(params): Query<PlainParams>) -> Result<Json<Value>, App
 pub async fn subreddit_info(
     State(mut state): State<AppState>,
     Query(params): Query<PlainParams>,
-) -> Result<Json<RedditSubredditInfo>, AppError> {
+) -> Result<Json<KindContainer>, AppError> {
     let subreddit = params
         .get("r")
         .ok_or_else(|| AppError::new(StatusCode::BAD_REQUEST, "Missing `subreddit` parameter"))?;
     let req = RedditRequest::SubredditInfo(subreddit.into());
     let json = state.reddit.fetch_raw(req).await?;
 
-    let info = serde_json::from_value::<RedditSubredditInfoRaw>(json).unwrap();
+    let info = serde_json::from_value::<KindContainer>(json).unwrap();
 
-    Ok(Json(info.data))
+    Ok(Json(info))
 }
 
-pub async fn subreddit_comments(
+pub async fn post_comments(
     State(mut state): State<AppState>,
     Query(params): Query<PlainParams>,
 ) -> Result<Json<Vec<KindContainer>>, AppError> {

--- a/backend/src/reddit/model/comment.rs
+++ b/backend/src/reddit/model/comment.rs
@@ -39,7 +39,9 @@ pub struct RedditComment {
     /// UNIX timestamp of the comment creation
     created_utc: f32,
     /// Depth of the comment in the thread. 0 is the top-level comment, 1 is a reply to the top-level comment, etc.
-    depth: u32,
+    ///
+    /// When fetching posts/comments from a user, this field is always `None`.
+    depth: Option<u32>,
     /// Upvotes - downvotes
     score: i64,
 }

--- a/backend/src/reddit/model/listing.rs
+++ b/backend/src/reddit/model/listing.rs
@@ -1,4 +1,4 @@
-use super::{comment::RedditComment, post::RedditPost, subreddit_info::RedditSubredditInfo};
+use super::{comment::RedditComment, post::RedditPost, subreddit_info::RedditSubredditInfo, user::RedditUser};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -15,7 +15,7 @@ pub enum KindContainer {
     T1(Box<RedditComment>), // Comment
 
     #[serde(rename = "t2")]
-    T2(Box<Value>), // Account TODO
+    T2(Box<RedditUser>), // Account TODO
 
     #[serde(rename = "t3")]
     T3(Box<RedditPost>), // Link/Post

--- a/backend/src/reddit/model/listing.rs
+++ b/backend/src/reddit/model/listing.rs
@@ -1,4 +1,4 @@
-use super::{comment::RedditComment, post::RedditPost};
+use super::{comment::RedditComment, post::RedditPost, subreddit_info::RedditSubredditInfo};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -15,19 +15,19 @@ pub enum KindContainer {
     T1(Box<RedditComment>), // Comment
 
     #[serde(rename = "t2")]
-    T2(Value), // Account TODO
+    T2(Box<Value>), // Account TODO
 
     #[serde(rename = "t3")]
     T3(Box<RedditPost>), // Link/Post
 
     #[serde(rename = "t4")]
-    T4(Value), // Message TODO
+    T4(Box<Value>), // Message TODO
 
     #[serde(rename = "t5")]
-    T5(Value), // Subreddit TODO
+    T5(Box<RedditSubredditInfo>), // Subreddit Info
 
     #[serde(rename = "t6")]
-    T6(Value), // Award TODO
+    T6(Box<Value>), // Award TODO
 }
 
 /// List of IDs of items to fetch to get the ones that didn't fit in the first response.

--- a/backend/src/reddit/model/subreddit_info.rs
+++ b/backend/src/reddit/model/subreddit_info.rs
@@ -2,12 +2,6 @@
 use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RedditSubredditInfoRaw {
-    pub kind: String,
-    pub data: RedditSubredditInfo
-}
-
 /// Reddit subreddit data
 /// https://www.reddit.com/r/Polska/about.json
 #[derive(Getters, Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/backend/src/reddit/reddit_error.rs
+++ b/backend/src/reddit/reddit_error.rs
@@ -13,15 +13,6 @@ pub enum RedditError {
     #[error("Domain '{0}' is not a valid Reddit API domain")]
     InvalidDomain(String),
 
-    #[error("Failed to read credentials file. It should be placed in the same dir as Cargo.toml")]
-    CredentialsNotFound,
-
-    #[error("Malformed .reddit-credentials.json file. Please make sure it's valid JSON")]
-    MalformedCredentials,
-
-    #[error("Credentials file contains no credentials in the array")]
-    NoClientsInCredentials,
-
     #[error("HTTP Error: `{0}`")]
     HttpError(#[from] reqwest::Error),
 


### PR DESCRIPTION
This PR adds all missing Reddit API debug endpoints, which return barely-processed data from Reddit. 

In the future it'll be stripped of Reddit's internal stuff like listings, kind containers etc. For now, it's useful to explore the API and prototype the UI. 

Closing #61 