### PR TITLE
Fetch wrapper with authorization

### DIFF
--- a/frontend/app/dashboard/DebugSubredditInfo.tsx
+++ b/frontend/app/dashboard/DebugSubredditInfo.tsx
@@ -1,0 +1,12 @@
+import Title from "../components/Title";
+import { fetchSubredditInfo } from "../rmoods/api";
+
+export default async function DebugSubredditInfo() {
+  const subredditData = await fetchSubredditInfo("Polska");
+  return (
+    <>
+      <Title>Debug subreddit info</Title>
+      <div>{JSON.stringify(subredditData, null, 2)}</div>
+    </>
+  );
+}

--- a/frontend/app/dashboard/DebugUserInfo.tsx
+++ b/frontend/app/dashboard/DebugUserInfo.tsx
@@ -1,0 +1,12 @@
+import Title from "../components/Title";
+import { fetchUserInfo } from "../rmoods/api";
+
+export default async function DebugUserInfo() {
+  const debugUserInfo = await fetchUserInfo("spez");
+  return (
+    <>
+      <Title>Debug user info</Title>
+      <div>{JSON.stringify(debugUserInfo, null, 2)}</div>
+    </>
+  );
+}

--- a/frontend/app/dashboard/LoggedUserInfo.tsx
+++ b/frontend/app/dashboard/LoggedUserInfo.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React from "react";
+import Title from "../components/Title";
+import { useAtomValue } from "jotai";
+import { userInfoAtom } from "../atoms";
+
+const LoggedUserInfo = () => {
+  const userInfo = useAtomValue(userInfoAtom);
+  return (
+    <>
+      <Title>Dashboard</Title>
+      <p>User Info</p>
+      <label>Name</label>
+      <p>{userInfo.name}</p>
+      <label>Email</label>
+      <p>{userInfo.email}</p>
+    </>
+  );
+};
+
+export default LoggedUserInfo;

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,20 +1,14 @@
-"use client";
-import { useAtomValue } from "jotai";
 import React from "react";
-import { userInfoAtom } from "../atoms";
-import Title from "../components/Title";
+import DebugRedditUserInfo from "./DebugUserInfo";
+import LoggedUserInfo from "./LoggedUserInfo";
+import DebugSubredditInfo from "./DebugSubredditInfo";
 
-const Dashboard = () => {
-  const userInfo = useAtomValue(userInfoAtom);
+const Dashboard = async () => {
   return (
     <>
-      <Title>Dashboard</Title>
-      <p>User Info</p>
-      <label>Name</label>
-      <p>{userInfo.name}</p>
-      <label>Email</label>
-      <p>{userInfo.email}</p>
-      
+      <LoggedUserInfo />
+      <DebugRedditUserInfo />
+      <DebugSubredditInfo />
     </>
   );
 };

--- a/frontend/app/rmoods/api.ts
+++ b/frontend/app/rmoods/api.ts
@@ -1,0 +1,31 @@
+"use server";
+// Just for now, those functions are in this single file.
+// Once the amount grows, we want to move them to a separate directory
+
+import { cookies } from "next/headers";
+import authFetch from "./authFetch";
+
+const EndpointMapper = {
+  "user-info": (u: string) => "/api/debug/user-info?u=" + u,
+  "subreddit-info": (r: string) => "/api/debug/subreddit-info?r=" + r,
+};
+
+async function fetchEndpoint(endpoint: string): Promise<object> {
+  const API_URL = "http://localhost:8001";
+  const token = cookies().get("RMOODS_JWT")?.value;
+  if (!token) {
+    throw new Error("No token found");
+  }
+  const response = await authFetch(API_URL + endpoint, token);
+  return response.json();
+}
+
+export async function fetchUserInfo(username: string): Promise<object> {
+  const endpoint = EndpointMapper["user-info"](username);
+  return fetchEndpoint(endpoint);
+}
+
+export async function fetchSubredditInfo(subreddit: string): Promise<object> {
+  const endpoint = EndpointMapper["subreddit-info"](subreddit);
+  return fetchEndpoint(endpoint);
+}

--- a/frontend/app/rmoods/authFetch.ts
+++ b/frontend/app/rmoods/authFetch.ts
@@ -1,0 +1,14 @@
+import { cookies } from "next/headers";
+
+export default function rmoodsFetch(endpoint: string, options: any = {}) {
+  const token = cookies().get("RMOODS_JWT");
+  const url = "http://localhost:3001" + endpoint;
+  const fullOptions = {
+    ...options,
+    headers: {
+      ...options.headers,
+      'Authorization': `Bearer ${token}`,
+    }
+  };
+  return fetch(url, fullOptions);
+}

--- a/frontend/app/rmoods/authFetch.ts
+++ b/frontend/app/rmoods/authFetch.ts
@@ -1,13 +1,14 @@
-import { cookies } from "next/headers";
-
-export default function rmoodsFetch(endpoint: string, options: any = {}) {
-  const token = cookies().get("RMOODS_JWT");
-  const url = "http://localhost:3001" + endpoint;
+export default async function authFetch(url: string | URL, token: string, options: any = {}) {
+  // Use the user-provided options, but always override the authorization header with our own.
+  // Opt into NextJS `fetch` caching behaviour by setting `revalidate` to 10 seconds.
   const fullOptions = {
     ...options,
     headers: {
       ...options.headers,
       'Authorization': `Bearer ${token}`,
+    },
+    next: {
+      revalidate: 10
     }
   };
   return fetch(url, fullOptions);


### PR DESCRIPTION
Implemented a wrapper around the default NextJS `fetch` function to add our authorization header with a JWT token obtained from cookies.

Created functions that wrap around the internals and abstract away the actual endpoints.

Also added some components to the Dashboard to test that API wrapper.
Closes #78 