### PR TITLE
119 improve theme switching

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -59,3 +59,5 @@ next-env.d.ts
 *.njsproj
 *.sln
 *.sw?
+
+dist

--- a/frontend/src/Providers.tsx
+++ b/frontend/src/Providers.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from "react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { Provider as JotaiProvider } from "jotai";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import { rmoodsTheme } from "./theme.ts";
+
+const Providers = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <StrictMode>
+      <GoogleOAuthProvider clientId="1055063718392-2ajj0s8h3pol9u5fdlt5vg8jep200r6i.apps.googleusercontent.com">
+        <ChakraProvider theme={rmoodsTheme} resetCSS>
+          <JotaiProvider>{children}</JotaiProvider>
+        </ChakraProvider>
+      </GoogleOAuthProvider>
+    </StrictMode>
+  );
+};
+
+export default Providers;

--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -1,3 +1,10 @@
 import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import { RMoodsColorMode } from "./theme";
 
 export const userInfoAtom = atom<any>({});
+
+export const colorModeAtom = atomWithStorage<RMoodsColorMode>(
+  "COLOR_MODE",
+  (localStorage.getItem("COLOR_MODE") as RMoodsColorMode) || "light",
+);

--- a/frontend/src/components/navbar/ThemeSwitch.tsx
+++ b/frontend/src/components/navbar/ThemeSwitch.tsx
@@ -28,11 +28,11 @@ const ThemeSwitch = () => {
 
     setTrueColorMode(nextMode);
 
-    if (nextMode === "system") {
-      if (colorMode !== systemMode) {
-        toggleColorMode();
-      }
-    } else if (nextMode !== colorMode) {
+    // Toggle ChakraUI color mode if it's different from the desired true mode
+    if (
+      (nextMode === "system" && colorMode !== systemMode) ||
+      (nextMode !== "system" && nextMode !== colorMode)
+    ) {
       toggleColorMode();
     }
   };

--- a/frontend/src/components/navbar/ThemeSwitch.tsx
+++ b/frontend/src/components/navbar/ThemeSwitch.tsx
@@ -1,20 +1,29 @@
-import { Button, useColorMode } from "@chakra-ui/react";
-import { getNextMode, getSystemMode, RMoodsColorMode } from "../../theme";
+import { Button, Icon, useColorMode, HStack } from "@chakra-ui/react";
+import { FaSun, FaMoon, FaDesktop } from "react-icons/fa";
+import { getNextMode, getSystemMode } from "../../theme";
 import { useAtom } from "jotai";
 import { useEffect } from "react";
-import { atomWithStorage } from "jotai/utils";
-
-// Initialize the atom using localStorage's current value, fallback to "light"
-const colorModeAtom = atomWithStorage<RMoodsColorMode>(
-  "COLOR_MODE",
-  (localStorage.getItem("COLOR_MODE") as RMoodsColorMode) || "light",
-);
+import { colorModeAtom } from "../../atoms";
 
 const ThemeSwitch = () => {
-  // ChakraUI handles only light and dark modes, so we need to keep track of the true color mode
   const { colorMode, toggleColorMode } = useColorMode();
   const [trueColorMode, setTrueColorMode] = useAtom(colorModeAtom);
 
+  // Determine the current icon based on the mode
+  const getIcon = () => {
+    switch (trueColorMode) {
+      case "light":
+        return FaSun;
+      case "dark":
+        return FaMoon;
+      case "system":
+        return FaDesktop;
+      default:
+        return FaSun;
+    }
+  };
+
+  // Handle system color scheme preference changes
   const handleSystemSchemeChange = () => {
     const systemMode = getSystemMode();
     if (trueColorMode === "system" && colorMode !== systemMode) {
@@ -22,13 +31,13 @@ const ThemeSwitch = () => {
     }
   };
 
+  // Handle theme change logic
   const onThemeChange = () => {
     const nextMode = getNextMode(trueColorMode);
     const systemMode = getSystemMode();
 
     setTrueColorMode(nextMode);
 
-    // Toggle ChakraUI color mode if it's different from the desired true mode
     if (
       (nextMode === "system" && colorMode !== systemMode) ||
       (nextMode !== "system" && nextMode !== colorMode)
@@ -46,10 +55,10 @@ const ThemeSwitch = () => {
 
   return (
     <header>
-      <Button onClick={onThemeChange}>
-        {trueColorMode === "system"
-          ? `System (${getSystemMode()})`
-          : trueColorMode.charAt(0).toUpperCase() + trueColorMode.slice(1)}
+      <Button onClick={onThemeChange} aria-label="Toggle Theme" px={4} py={2}>
+        <HStack spacing={2}>
+          <Icon as={getIcon()} boxSize={5} />
+        </HStack>
       </Button>
     </header>
   );

--- a/frontend/src/components/navbar/ThemeSwitch.tsx
+++ b/frontend/src/components/navbar/ThemeSwitch.tsx
@@ -1,12 +1,55 @@
 import { Button, useColorMode } from "@chakra-ui/react";
+import {
+  DEFAULT_COLOR_MODE,
+  getNextMode,
+  getSystemMode,
+  RMoodsColorMode,
+} from "../../theme";
+import { useState } from "react";
 
 const ThemeSwitch = () => {
+  if (!localStorage.getItem("COLOR_MODE")) {
+    localStorage.setItem("COLOR_MODE", DEFAULT_COLOR_MODE);
+  }
+  let currentMode = localStorage.getItem("COLOR_MODE");
+  const [trueColorMode, setTrueColorMode] = useState(currentMode);
+
   const { colorMode, toggleColorMode } = useColorMode();
+  if (!colorMode) {
+    return <></>;
+  }
+
+  const onSystemColorSchemeChange = () => {
+    const newPreference = getSystemMode();
+    if (localStorage.getItem("COLOR_MODE") === "system") {
+      if (newPreference !== colorMode) {
+        toggleColorMode();
+      }
+    }
+  };
+
+  const handleThemeChange = () => {
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", () => onSystemColorSchemeChange());
+    const currentMode = (localStorage.getItem("COLOR_MODE") ||
+      "light") as RMoodsColorMode;
+    const nextMode = getNextMode(currentMode);
+    const systemPreference = getSystemMode();
+    localStorage.setItem("COLOR_MODE", nextMode);
+    setTrueColorMode(nextMode);
+    if (nextMode === "system") {
+      if (colorMode !== systemPreference) {
+        toggleColorMode();
+      }
+    } else if (nextMode !== colorMode) {
+      toggleColorMode();
+    }
+  };
+
   return (
     <header>
-      <Button onClick={toggleColorMode}>
-        Toggle to {colorMode === "light" ? "Dark" : "Light"}
-      </Button>
+      <Button onClick={() => handleThemeChange()}>{trueColorMode}</Button>
     </header>
   );
 };

--- a/frontend/src/components/navbar/UserMenu.tsx
+++ b/frontend/src/components/navbar/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { Link, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
+import { Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
 import Cookies from "js-cookie";
 import { useNavigate } from "react-router-dom";
 
@@ -14,9 +14,7 @@ const UserMenu = () => {
     <Menu id="user-dropdown">
       <MenuButton>User Menu</MenuButton>
       <MenuList>
-        <MenuItem>
-          <Link href="/dashboard">Dashboard</Link>
-        </MenuItem>
+        <MenuItem onClick={() => navigate("/dashboard")}>Dashboard</MenuItem>
         <MenuItem onClick={() => handleLogout()}>Log out</MenuItem>
       </MenuList>
     </Menu>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,21 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { ChakraProvider } from "@chakra-ui/react";
-import { Provider as JotaiProvider } from "jotai";
 import "./index.css";
 import { RouterProvider } from "react-router-dom";
 import router from "./router.tsx";
-import { GoogleOAuthProvider } from "@react-oauth/google";
-import rmoodsTheme from "./theme.ts";
+import Providers from "./Providers.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId="1055063718392-2ajj0s8h3pol9u5fdlt5vg8jep200r6i.apps.googleusercontent.com">
-      <ChakraProvider theme={rmoodsTheme} resetCSS>
-        <JotaiProvider>
-          <RouterProvider router={router} />
-        </JotaiProvider>
-      </ChakraProvider>
-    </GoogleOAuthProvider>
+    <Providers>
+      <RouterProvider router={router} />
+    </Providers>
   </StrictMode>,
 );

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,16 +1,43 @@
 import { extendTheme, type ThemeConfig } from '@chakra-ui/react'
 
+export type RMoodsColorMode = 'light' | 'dark' | 'system';
+export const DEFAULT_COLOR_MODE: RMoodsColorMode = localStorage.getItem('COLOR_MODE') as RMoodsColorMode || 'light';
+
+export const getSystemMode = (): 'light' | 'dark' => {
+  if (window.matchMedia) {
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark'
+    }
+  }
+  return 'light'
+}
+
+export const getNextMode = (currentMode: RMoodsColorMode): RMoodsColorMode => {
+  console.log('Next mode for', currentMode)
+  switch (currentMode) {
+    case 'light':
+      return 'dark'
+    case 'dark':
+      return 'system'
+    case 'system':
+      return 'light'
+  }
+}
+
+if (!localStorage.getItem("COLOR_MODE")) {
+  localStorage.setItem("COLOR_MODE", DEFAULT_COLOR_MODE);
+}
 const config: ThemeConfig = {
-  initialColorMode: 'light',
+  initialColorMode: localStorage.getItem('COLOR_MODE') as RMoodsColorMode,
   useSystemColorMode: false,
   disableTransitionOnChange: false,
 }
 
-const rmoodsTheme = extendTheme({
+export const rmoodsTheme = extendTheme({
   components: {
     Card: {
       baseStyle: {
-        container:{
+        container: {
           padding: 4,
           margin: 4,
         }
@@ -26,5 +53,3 @@ const rmoodsTheme = extendTheme({
     }
   }
 })
-
-export default rmoodsTheme;


### PR DESCRIPTION
I've built a wrapper around ChakraUI's poor handling of themes (they call them "color modes").

The wrapper adds functionality related to following the system theme. It updates everything in real time and uses Jotai to keep state in local storage.

I've also used React Icons to illustrate the current state.

Closes #119 