### PR TITLE
127: Add git hook standardizing commit messages

### DIFF
--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+message=$(cat "$1")
+
+pattern="^[0-9]+: .*$|^Merge.*$|^merge.*$"
+
+if [[ ! $message =~ $pattern ]]; then
+    echo 
+    echo "---------------------------------------------------------------------------------------------------------"
+    echo "Error: Rejecting commit message. It appears to be missing GitHub Issue information or merge information."
+    echo 
+    echo "Accepted message prefixes: '<number>: ', 'Merge', 'merge'"
+    echo "Example: '121: refactor'"
+    echo "---------------------------------------------------------------------------------------------------------"
+    echo
+  exit 1
+fi

--- a/.github/install_hooks.sh
+++ b/.github/install_hooks.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd $(git rev-parse --show-toplevel)
+chmod +x .github/hooks/*
+cp .github/hooks/* .git/hooks
+echo "Hooks installed successfully"
+

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ TODO
 ## Documentation
 The documentation for each module is available [here](https://rmoodsteam.github.io/RMoods/).
 
+## Setup
+**TODO** Other setup steps
+
+For development, install our git hooks by running the install script:
+```sh
+sh .github/install_hooks.sh
+```
+
 ## Authors
 * [Katarzyna Jabłońska](https://github.com/katJablonska)
 * [Michał Miłek](https://github.com/m-milek)


### PR DESCRIPTION
Added a git hook ensuring proper commit message tagging.
Numbering commits will make it easier to associate commits with GitHub Issues

Closing #127 