### PR TITLE
182 websocket status indicator

### DIFF
--- a/frontend/src/Providers.tsx
+++ b/frontend/src/Providers.tsx
@@ -11,14 +11,16 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <StrictMode>
-      <MantineProvider defaultColorScheme={colorScheme}>
-        <Notifications />
-        <WebsocketProvider>
-          <GoogleOAuthProvider clientId="1055063718392-2ajj0s8h3pol9u5fdlt5vg8jep200r6i.apps.googleusercontent.com">
-            <JotaiProvider>{children}</JotaiProvider>
-          </GoogleOAuthProvider>
-        </WebsocketProvider>
-      </MantineProvider>
+      <JotaiProvider>
+        <MantineProvider defaultColorScheme={colorScheme}>
+          <Notifications />
+          <WebsocketProvider>
+            <GoogleOAuthProvider clientId="1055063718392-2ajj0s8h3pol9u5fdlt5vg8jep200r6i.apps.googleusercontent.com">
+              {children}
+            </GoogleOAuthProvider>
+          </WebsocketProvider>
+        </MantineProvider>
+      </JotaiProvider>
     </StrictMode>
   );
 };

--- a/frontend/src/WebsocketProvider.tsx
+++ b/frontend/src/WebsocketProvider.tsx
@@ -1,25 +1,21 @@
-import { useEffect } from 'react';
 import Cookies from 'js-cookie';
-import { useAtom, useSetAtom } from 'jotai';
-import { atom } from 'jotai';
+import { useAtom } from 'jotai';
 import { notifications } from '@mantine/notifications';
-
-export const wsConnectionStatusAtom = atom<boolean>(false);
+import { useEffect, useRef } from 'react';
+import { wsConnectionStatusAtom } from './atoms.ts';
 
 const WebsocketProvider = ({ children }: { children: React.ReactNode }) => {
   console.log('WebsocketProvider: rendering');
-  const [wsConnection, setWsConnectionStatus] = useAtom(wsConnectionStatusAtom);
-      const wsClient = new WebSocket(
-        `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`
-      );
+
+  const connection = useRef<WebSocket | null>(null);
+  const [, setWsConnectionStatus] = useAtom(wsConnectionStatusAtom);
 
   useEffect(() => {
-    console.log('WebSocket connection status updated:', {wsConnection, timestamp: new Date().toISOString(),});
-  }, [wsConnection]);
+    const ws = new WebSocket(
+      `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`
+    );
 
-  useEffect(() => {
-
-    wsClient.onmessage = (event) => {
+    ws.onmessage = (event) => {
       console.log('Received WebSocket message');
       console.log(JSON.stringify(event.data));
       notifications.show({
@@ -31,13 +27,12 @@ const WebsocketProvider = ({ children }: { children: React.ReactNode }) => {
       });
     };
 
-    wsClient.onopen = () => {
+    ws.onopen = () => {
       console.log('WebSocket connection opened.');
       setWsConnectionStatus(true);
-      console.log('WebSocket connection status:' , wsConnection);
     };
 
-    wsClient.onerror = (event) => {
+    ws.onerror = (event) => {
       console.error(event);
       notifications.show({
         title: 'WebSocket Error',
@@ -46,18 +41,16 @@ const WebsocketProvider = ({ children }: { children: React.ReactNode }) => {
         icon: '',
       });
       setWsConnectionStatus(false);
-      console.log('WebSocket connection status:',  wsConnection);
     };
 
-    wsClient.onclose = () => {
-      console.log('WebSocket connection closed.');
+    ws.onclose = () => {
       setWsConnectionStatus(false);
     };
 
-    // return () => {
-    //   wsClient.close();
-    //   setWsConnectionStatus(false);
-    // };
+    connection.current = ws;
+    return () => {
+      ws.close();
+    };
   }, []);
 
   return <>{children}</>;

--- a/frontend/src/WebsocketProvider.tsx
+++ b/frontend/src/WebsocketProvider.tsx
@@ -1,25 +1,83 @@
-import WebSocketConnection, {
-  wsConnectionStatusAtom,
-} from './rmoods/websockets/wsClient.ts';
 import { useEffect } from 'react';
-import { useSetAtom } from 'jotai';
+import Cookies from 'js-cookie';
+import { useAtom, useSetAtom } from 'jotai';
+import { atom } from 'jotai';
+import { notifications } from '@mantine/notifications';
+
+export const wsConnectionStatusAtom = atom<boolean>(false);
 
 const WebsocketProvider = ({ children }: { children: React.ReactNode }) => {
-  let webSocketConnection: WebSocketConnection | null = null;
-  const setWsConnectionStatus = useSetAtom(wsConnectionStatusAtom);
+  console.log('WebsocketProvider: rendering');
+  const [wsConnection, setWsConnectionStatus] = useAtom(wsConnectionStatusAtom);
+      const wsClient = new WebSocket(
+        `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`
+      );
 
-  // SN: in case of problems with connection maybe use useEffect for this one
-  //
-  // MM: This sucks. React calls useEffect twice due to Strict Mode.
-  // We have to determine if that's something that we actually want to use or
-  // for now we're fine with double rendering and effect running.
-  // I'll leave it as it is for now, seems to be working somehow.
   useEffect(() => {
-    if (webSocketConnection == null) {
-      webSocketConnection = new WebSocketConnection(setWsConnectionStatus);
-    }
-  }, [setWsConnectionStatus]);
+    console.log('WebSocket connection status updated:', {wsConnection, timestamp: new Date().toISOString(),});
+  }, [wsConnection]);
+
+  useEffect(() => {
+
+    wsClient.onmessage = (event) => {
+      console.log('Received WebSocket message');
+      console.log(JSON.stringify(event.data));
+      notifications.show({
+        title: 'WebSocket Message',
+        message:
+          'Received a message from the WebSocket connection. Logged in console',
+        color: 'blue',
+        icon: '',
+      });
+    };
+
+    wsClient.onopen = () => {
+      console.log('WebSocket connection opened.');
+      setWsConnectionStatus(true);
+      console.log('WebSocket connection status:' , wsConnection);
+    };
+
+    wsClient.onerror = (event) => {
+      console.error(event);
+      notifications.show({
+        title: 'WebSocket Error',
+        message: 'An error occurred with the WebSocket connection.',
+        color: 'red',
+        icon: '',
+      });
+      setWsConnectionStatus(false);
+      console.log('WebSocket connection status:',  wsConnection);
+    };
+
+    wsClient.onclose = () => {
+      console.log('WebSocket connection closed.');
+      setWsConnectionStatus(false);
+    };
+
+    // return () => {
+    //   wsClient.close();
+    //   setWsConnectionStatus(false);
+    // };
+  }, []);
+
   return <>{children}</>;
 };
 
 export default WebsocketProvider;
+
+// SN: in case of problems with connection maybe use useEffect for this one
+//
+// MM: This sucks. React calls useEffect twice due to Strict Mode.
+// We have to determine if that's something that we actually want to use or
+// for now we're fine with double rendering and effect running.
+// I'll leave it as it is for now, seems to be working somehow.
+//
+//   useEffect(() => {
+//     if (webSocketConnection == null) {
+//       webSocketConnection = new WebSocketConnection(setWsConnectionStatus);
+//     }
+//   }, [setWsConnectionStatus]);
+//   return <>{children}</>;
+// };
+
+// export default WebsocketProvider;

--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -8,3 +8,5 @@ export const colorModeAtom = atomWithStorage<MantineColorScheme>(
   'COLOR_MODE',
   (localStorage.getItem('COLOR_MODE') as MantineColorScheme) || 'light'
 );
+
+export const wsConnectionStatusAtom = atom<boolean>(false);

--- a/frontend/src/components/navbar/Navbar.tsx
+++ b/frontend/src/components/navbar/Navbar.tsx
@@ -1,6 +1,7 @@
 import UserMenu from './UserMenu';
 import ThemeSwitch from './ThemeSwitch';
 import { Anchor, Card, Flex, Grid } from '@mantine/core';
+import StatusIndicator from './StatusIndicator';
 
 const LeftNavItems = () => {
   return (
@@ -13,7 +14,8 @@ const LeftNavItems = () => {
 
 const RightNavItems = () => {
   return (
-    <Flex gap={10} justify={'right'}>
+    <Flex gap={10} justify={'right'} align="center">
+      <StatusIndicator />
       <ThemeSwitch />
       <UserMenu />
     </Flex>

--- a/frontend/src/components/navbar/StatusIndicator.tsx
+++ b/frontend/src/components/navbar/StatusIndicator.tsx
@@ -5,22 +5,18 @@ import { wsConnectionStatusAtom } from '../../atoms.ts';
 
 const StatusIndicator = () => {
   const isConnected = useAtomValue(wsConnectionStatusAtom);
-  console.log('StatusIndicator: rendering');
-  console.log('StatusIndicator: connection status:', isConnected);
+
+  const tooltipLabel = isConnected
+    ? `Connected to the RMoods Server`
+    : `Disconnected from the RMoods Server`;
 
   return (
-    <Tooltip
-      label={`WebSocket Status: ${isConnected} (${new Date().toLocaleTimeString()})`}
-    >
+    <Tooltip label={tooltipLabel} openDelay={300}>
       <ActionIcon
         size="xs"
         radius="100%"
         color={isConnected ? 'green' : 'red'}
-        style={{
-          border: '2px solid rgba(0, 0, 0, 0.5)',
-          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
-        }}
-        onClick={() => console.log('Current ws status:', isConnected)}
+        style={{ cursor: 'default' }}
       />
     </Tooltip>
   );

--- a/frontend/src/components/navbar/StatusIndicator.tsx
+++ b/frontend/src/components/navbar/StatusIndicator.tsx
@@ -1,17 +1,12 @@
-import React, { useEffect } from 'react';
-import { useAtom } from 'jotai';
-import { wsConnectionStatusAtom } from '../../WebsocketProvider';
+import React from 'react';
+import { useAtomValue } from 'jotai';
 import { ActionIcon, Tooltip } from '@mantine/core';
+import { wsConnectionStatusAtom } from '../../atoms.ts';
 
 const StatusIndicator = () => {
-  const [isConnected] = useAtom(wsConnectionStatusAtom);
-  
-  useEffect(() => {
-    console.log('StatusIndicator: connection status changed:', {
-      isConnected,
-      timestamp: new Date().toISOString(),
-    });
-  }, [isConnected]);
+  const isConnected = useAtomValue(wsConnectionStatusAtom);
+  console.log('StatusIndicator: rendering');
+  console.log('StatusIndicator: connection status:', isConnected);
 
   return (
     <Tooltip

--- a/frontend/src/components/navbar/StatusIndicator.tsx
+++ b/frontend/src/components/navbar/StatusIndicator.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+import { useAtom } from 'jotai';
+import { wsConnectionStatusAtom } from '../../WebsocketProvider';
+import { ActionIcon, Tooltip } from '@mantine/core';
+
+const StatusIndicator = () => {
+  const [isConnected] = useAtom(wsConnectionStatusAtom);
+  
+  useEffect(() => {
+    console.log('StatusIndicator: connection status changed:', {
+      isConnected,
+      timestamp: new Date().toISOString(),
+    });
+  }, [isConnected]);
+
+  return (
+    <Tooltip
+      label={`WebSocket Status: ${isConnected} (${new Date().toLocaleTimeString()})`}
+    >
+      <ActionIcon
+        size="xs"
+        radius="100%"
+        color={isConnected ? 'green' : 'red'}
+        style={{
+          border: '2px solid rgba(0, 0, 0, 0.5)',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+        }}
+        onClick={() => console.log('Current ws status:', isConnected)}
+      />
+    </Tooltip>
+  );
+};
+
+export default StatusIndicator;

--- a/frontend/src/rmoods/websockets/wsClient.ts
+++ b/frontend/src/rmoods/websockets/wsClient.ts
@@ -1,54 +1,54 @@
-import Cookies from 'js-cookie';
-import { atom } from 'jotai';
-import { notifications } from '@mantine/notifications';
+// import Cookies from 'js-cookie';
+// import { atom } from 'jotai';
+// import { notifications } from '@mantine/notifications';
 
-// Define an atom to store the WebSocket connection status
-// for now the atom manipulation is in the onerror function as it was the easiest to test on
-// later we can think about mocking the websocket connection but right now I'd focus on changing chakra version
-// because more and more components will demand bigger refactor as we develop frontend
-export const wsConnectionStatusAtom = atom<boolean>(false);
+// // Define an atom to store the WebSocket connection status
+// // for now the atom manipulation is in the onerror function as it was the easiest to test on
+// // later we can think about mocking the websocket connection but right now I'd focus on changing chakra version
+// // because more and more components will demand bigger refactor as we develop frontend
+// export const wsConnectionStatusAtom = atom<boolean>(false);
 
-class WebSocketConnection {
-  constructor(setWsConnectionStatus: (status: boolean) => void) {
-    const wsClient = new WebSocket(
-      `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`
-    );
+// class WebSocketConnection {
+//   constructor(setWsConnectionStatus: (status: boolean) => void) {
+//     const wsClient = new WebSocket(
+//       `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`
+//     );
 
-    wsClient.onmessage = (event) => {
-      console.log('Received WebSocket message');
-      console.log(JSON.stringify(event.data));
-      notifications.show({
-        title: 'WebSocket Message',
-        message:
-          'Received a message from the WebSocket connection. Logged in console',
-        color: 'blue',
-        icon: '',
-      });
-    };
+//     wsClient.onmessage = (event) => {
+//       console.log('Received WebSocket message');
+//       console.log(JSON.stringify(event.data));
+//       notifications.show({
+//         title: 'WebSocket Message',
+//         message:
+//           'Received a message from the WebSocket connection. Logged in console',
+//         color: 'blue',
+//         icon: '',
+//       });
+//     };
 
-    wsClient.onopen = () => {
-      console.log('WebSocket connection opened.');
-      setWsConnectionStatus(true); // Set the atom to true
-    };
+//     wsClient.onopen = () => {
+//       console.log('WebSocket connection opened.');
+//       setWsConnectionStatus(true); // Set the atom to true
+//     };
 
-    wsClient.onerror = (event) => {
-      console.error(event);
+//     wsClient.onerror = (event) => {
+//       console.error(event);
 
-      notifications.show({
-        title: 'WebSocket Error',
-        message: 'An error occurred with the WebSocket connection.',
-        color: 'red',
-        icon: '',
-      });
+//       notifications.show({
+//         title: 'WebSocket Error',
+//         message: 'An error occurred with the WebSocket connection.',
+//         color: 'red',
+//         icon: '',
+//       });
 
-      setWsConnectionStatus(false); // Set the atom to false
-      console.log('WebSocket connection status:', false);
-    };
+//       setWsConnectionStatus(false); // Set the atom to false
+//       console.log('WebSocket connection status:', false);
+//     };
 
-    wsClient.onclose = () => {
-      console.log('WebSocket connection closed.');
-    };
-  }
-}
+//     wsClient.onclose = () => {
+//       console.log('WebSocket connection closed.');
+//     };
+//   }
+// }
 
-export default WebSocketConnection;
+// export default WebSocketConnection;


### PR DESCRIPTION
This pull request includes significant changes to the WebSocket connection handling and UI updates to indicate connection status. The most important changes include refactoring the `WebsocketProvider` component to use native WebSocket API and Jotai for state management, and adding a new `StatusIndicator` component to show the WebSocket connection status in the navbar.

### WebSocket Connection Handling:

* [`frontend/src/WebsocketProvider.tsx`](diffhunk://#diff-aa8377f5cb5e5423758d961cf490f5b8c8c76221a02ff1e527c92ed41f4216c2L1-R76): Refactored to use native WebSocket API and Jotai for state management. Added connection status notifications and updated the WebSocket connection logic.
* [`frontend/src/rmoods/websockets/wsClient.ts`](diffhunk://#diff-53b3f25fb1af993d57c80fa77e9e8a65e87e1ff2666b29084e74d68ab490584aL1-R54): Deprecated the old WebSocket connection class in favor of the new implementation using native WebSocket API in `WebsocketProvider`.

### State Management:

* [`frontend/src/atoms.ts`](diffhunk://#diff-87a37ed01ac97edcb3782f6dfed0e9624272b79d69d4a5614b58e241acdd7ba7R11-R12): Added `wsConnectionStatusAtom` to manage the WebSocket connection status using Jotai.

### UI Updates:

* [`frontend/src/components/navbar/Navbar.tsx`](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeR4): Added the `StatusIndicator` component to the right side of the navigation bar to display WebSocket connection status. [[1]](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeR4) [[2]](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeL16-R18)
* [`frontend/src/components/navbar/StatusIndicator.tsx`](diffhunk://#diff-6761b0118b5eae4db16f730dc9a0f6a40d1dba3d3b4f494c63dc22ba797ba8f4R1-R25): Created a new component to show connection status with a tooltip indicating whether the connection to the RMoods server is active.

### Provider Wrapping:

* [`frontend/src/Providers.tsx`](diffhunk://#diff-ed9024136071c71dbbbd18513b9466a39092fd4563c99dad4ad25711332f270eR14-R23): Adjusted the wrapping of `JotaiProvider` to ensure proper context usage.