### PR TITLE
177 complete nlp api client on the backend

### DIFF
--- a/backend/src/api/auth/login.rs
+++ b/backend/src/api/auth/login.rs
@@ -46,11 +46,7 @@ pub async fn login(
         user_info.email_verified
     )
     .execute(&state.pool)
-    .await
-    .or_else(|e| {
-        log::error!("Failed to insert user info into the database: {:?}", e);
-        Err(AppError::internal_server_error())
-    })?;
+    .await?;
 
     log::debug!("User logged in: {:?}", user_info);
 

--- a/backend/src/api/report/generate.rs
+++ b/backend/src/api/report/generate.rs
@@ -1,8 +1,9 @@
 use crate::api::auth::google::{GoogleId, JwtUserInfo};
 use crate::api::report::report_ack::ReportAck;
 use crate::app_error::AppError;
+use crate::nlp::analysis::NlpAnalysisKind;
 use crate::nlp::nlp_client::NlpClient;
-use crate::nlp::report::{new_report_id, NlpAnalyses, RMoodsReport, ReportMetadata};
+use crate::nlp::report::{new_report_id, RMoodsReport, ReportMetadata};
 use crate::reddit_fetcher::feed_request::{FetcherFeedRequest, RedditFeedKind};
 use crate::reddit_fetcher::fetcher::RMoodsFetcher;
 use crate::reddit_fetcher::model::post_comments::PostComments;
@@ -14,6 +15,7 @@ use crate::websocket::SystemMessage::ReportError;
 use crate::AppState;
 use axum::extract::State;
 use jsonwebtoken::get_current_timestamp;
+use std::collections::HashMap;
 
 /// Create a report from the given data.
 ///
@@ -32,9 +34,7 @@ pub async fn nlp_analysis<T: RedditFeedData>(
             user_id,
             is_public: true,
         },
-        analyses: NlpAnalyses {
-            language: Some(language_analysis),
-        },
+        analyses: HashMap::from([(NlpAnalysisKind::Language, language_analysis)]),
     };
     Ok(report)
 }

--- a/backend/src/api/report/generate.rs
+++ b/backend/src/api/report/generate.rs
@@ -26,7 +26,9 @@ pub async fn nlp_analysis<T: RedditFeedData>(
     user_id: GoogleId,
 ) -> Result<RMoodsReport, AppError> {
     let texts = data.extract_texts();
-    let language_analysis = nlp_client.analyze_language(&texts).await?;
+    let language_analysis = nlp_client
+        .analyze(NlpAnalysisKind::Language, &texts)
+        .await?;
     let report = RMoodsReport {
         id: new_report_id(),
         metadata: ReportMetadata {

--- a/backend/src/nlp/analysis.rs
+++ b/backend/src/nlp/analysis.rs
@@ -9,5 +9,5 @@ pub enum NlpAnalysisKind {
     Politics,
     HateSpeech,
     Clickbait,
-    Keyword,
+    Keywords,
 }

--- a/backend/src/nlp/analysis.rs
+++ b/backend/src/nlp/analysis.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Hash, Eq)]
+pub enum NlpAnalysisKind {
+    Language,
+    Sentiment,
+    Sarcasm,
+    Spam,
+    Politics,
+    HateSpeech,
+    Clickbait,
+    Keyword,
+}

--- a/backend/src/nlp/analysis.rs
+++ b/backend/src/nlp/analysis.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+/// The kind of analysis to perform.
+/// This is used to determine the endpoint to hit on the NLP service.
+/// The NLP service will return a response with the same kind of analysis.
+///
+/// Each analysis uses a different NLP model to analyze the text.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NlpAnalysisKind {

--- a/backend/src/nlp/analysis.rs
+++ b/backend/src/nlp/analysis.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Hash, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum NlpAnalysisKind {
     Language,
     Sentiment,

--- a/backend/src/nlp/error.rs
+++ b/backend/src/nlp/error.rs
@@ -1,9 +1,12 @@
 use thiserror::Error;
 
+/// An error that can occur when interacting with the NLP Service.
 #[derive(Debug, Error)]
 pub enum NlpError {
+    /// Occurs when the NLP Service returns a response of unexpected format.
     #[error("Failed to deserialize NLP response: {0}")]
     NlpSerdeError(#[from] serde_json::Error),
+    /// Occurs when communication with NLP Service has failed.
     #[error("Failed to communicate with NLP service: {0}")]
     NlpHttpError(#[from] reqwest::Error),
 }

--- a/backend/src/nlp/mod.rs
+++ b/backend/src/nlp/mod.rs
@@ -1,3 +1,4 @@
+pub mod analysis;
 pub mod error;
 pub mod nlp_client;
 pub mod nlp_response;

--- a/backend/src/nlp/nlp_client.rs
+++ b/backend/src/nlp/nlp_client.rs
@@ -143,6 +143,51 @@ mod tests {
 
     #[ignore]
     #[tokio::test]
+    async fn test_get_hate_speech() {
+        setup();
+        let client = NlpClient::new();
+        let input = vec!["I hate you!".to_string(), "I love you!".to_string()];
+        let res = client
+            .analyze(NlpAnalysisKind::HateSpeech, &input)
+            .await
+            .unwrap();
+        dbg!(res);
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_clickbait() {
+        setup();
+        let client = NlpClient::new();
+        let input = vec![
+            "You won't believe what happens next!".to_string(),
+            "Hello, world!".to_string(),
+        ];
+        let res = client
+            .analyze(NlpAnalysisKind::Clickbait, &input)
+            .await
+            .unwrap();
+        dbg!(res);
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_keywords() {
+        setup();
+        let client = NlpClient::new();
+        let input = vec![
+            "Hello, world!".to_string(),
+            "Bonjour, le monde!".to_string(),
+        ];
+        let res = client
+            .analyze(NlpAnalysisKind::Keywords, &input)
+            .await
+            .unwrap();
+        dbg!(res);
+    }
+
+    #[ignore]
+    #[tokio::test]
     async fn test_get_politics() {
         setup();
         let client = NlpClient::new();

--- a/backend/src/nlp/nlp_client.rs
+++ b/backend/src/nlp/nlp_client.rs
@@ -1,8 +1,10 @@
 use crate::env::NLP_URL;
+use crate::nlp::analysis::NlpAnalysisKind;
 use crate::nlp::error::NlpError;
 use crate::nlp::nlp_response::NlpAnalysis;
 use log_derive::logfn;
 use serde_with::serde_derive::Serialize;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct NlpClient {
@@ -40,9 +42,27 @@ impl NlpClient {
         }
     }
 
+    fn url_for_analysis(analysis: NlpAnalysisKind) -> &'static str {
+        type A = NlpAnalysisKind;
+        match analysis {
+            A::Language => "/language",
+            A::Sentiment => "/sentiment",
+            A::Sarcasm => "/sarcasm",
+            A::Spam => "/spam",
+            A::Politics => "/politics",
+            A::HateSpeech => "/hate-speech",
+            A::Clickbait => "/clickbait",
+            A::Keywords => "/keywords",
+        }
+    }
+
     #[logfn(err = "ERROR", fmt = "Failed to analyze language: {0:?}")]
-    pub async fn analyze_language(&self, input: &Vec<String>) -> Result<NlpAnalysis, NlpError> {
-        let url = format!("{}/report/language", self.nlp_url);
+    pub async fn analyze(
+        &self,
+        kind: NlpAnalysisKind,
+        input: &Vec<String>,
+    ) -> Result<NlpAnalysis, NlpError> {
+        let url = format!("{}{}", self.nlp_url, Self::url_for_analysis(kind));
 
         log::debug!("Handling only first 10 inputs. Truncating each input to 100 characters.");
         // TODO: Add parallel processing for large inputs, input sampling
@@ -75,7 +95,65 @@ mod tests {
             "Hello, world!".to_string(),
             "Bonjour, le monde!".to_string(),
         ];
-        let res = client.analyze_language(&input).await.unwrap();
+        let res = client
+            .analyze(NlpAnalysisKind::Language, &input)
+            .await
+            .unwrap();
+        dbg!(res);
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_sentiment() {
+        setup();
+        let client = NlpClient::new();
+        let input = vec!["I love this!".to_string(), "I hate this!".to_string()];
+        let res = client
+            .analyze(NlpAnalysisKind::Sentiment, &input)
+            .await
+            .unwrap();
+        dbg!(res);
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_sarcasm() {
+        setup();
+        let client = NlpClient::new();
+        let input = vec!["I love this!".to_string(), "I hate this!".to_string()];
+        let res = client
+            .analyze(NlpAnalysisKind::Sarcasm, &input)
+            .await
+            .unwrap();
+        dbg!(res);
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_spam() {
+        setup();
+        let client = NlpClient::new();
+        let input = vec![
+            "Click here to win a free iPhone!".to_string(),
+            "Hello, world!".to_string(),
+        ];
+        let res = client.analyze(NlpAnalysisKind::Spam, &input).await.unwrap();
+        dbg!(res);
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_politics() {
+        setup();
+        let client = NlpClient::new();
+        let input = vec![
+            "Democrats are great!".to_string(),
+            "Republicans are great!".to_string(),
+        ];
+        let res = client
+            .analyze(NlpAnalysisKind::Politics, &input)
+            .await
+            .unwrap();
         dbg!(res);
     }
 }

--- a/backend/src/nlp/nlp_client.rs
+++ b/backend/src/nlp/nlp_client.rs
@@ -4,7 +4,6 @@ use crate::nlp::error::NlpError;
 use crate::nlp::nlp_response::NlpAnalysis;
 use log_derive::logfn;
 use serde_with::serde_derive::Serialize;
-use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct NlpClient {

--- a/backend/src/nlp/nlp_client.rs
+++ b/backend/src/nlp/nlp_client.rs
@@ -1,13 +1,18 @@
 use crate::env::NLP_URL;
 use crate::nlp::error::NlpError;
-use crate::nlp::nlp_response::{NlpResponse, RawLanguageResponse};
+use crate::nlp::nlp_response::NlpAnalysis;
 use log_derive::logfn;
-use serde_json::json;
+use serde_with::serde_derive::Serialize;
 
 #[derive(Debug, Clone)]
 pub struct NlpClient {
     nlp_url: String,
     pub http: reqwest::Client,
+}
+
+#[derive(Serialize, Debug)]
+struct NlpRequest {
+    text: Vec<String>,
 }
 
 /// Truncate a string to a maximum length.
@@ -20,6 +25,13 @@ fn truncate_string(s: String, max_len: usize) -> String {
     }
 }
 
+fn truncate_inputs(input: &[String], max_len: usize) -> Vec<String> {
+    input
+        .iter()
+        .map(|s| truncate_string(s.clone(), max_len))
+        .collect()
+}
+
 impl NlpClient {
     pub fn new() -> Self {
         NlpClient {
@@ -29,17 +41,14 @@ impl NlpClient {
     }
 
     #[logfn(err = "ERROR", fmt = "Failed to analyze language: {0:?}")]
-    pub async fn analyze_language(
-        &self,
-        input: &Vec<String>,
-    ) -> Result<NlpResponse<RawLanguageResponse>, NlpError> {
+    pub async fn analyze_language(&self, input: &Vec<String>) -> Result<NlpAnalysis, NlpError> {
         let url = format!("{}/report/language", self.nlp_url);
 
         log::debug!("Handling only first 10 inputs. Truncating each input to 100 characters.");
         // TODO: Add parallel processing for large inputs, input sampling
-        let request = json!({
-            "text": input.iter().take(10).map(|s| truncate_string(s.clone(), 100)).collect::<Vec<String>>(),
-        });
+        let request = NlpRequest {
+            text: truncate_inputs(input, 100),
+        };
 
         log::debug!("Sending request to NLP service: {:?}", request);
 

--- a/backend/src/nlp/nlp_response.rs
+++ b/backend/src/nlp/nlp_response.rs
@@ -19,7 +19,7 @@ pub struct NlpMetadata {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NlpResponse {
     pub label: Vec<String>,
-    pub confidence: Vec<String>,
+    pub confidence: Vec<f64>,
 }
 
 /// Generic NLP response type.

--- a/backend/src/nlp/nlp_response.rs
+++ b/backend/src/nlp/nlp_response.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 /// Metadata for the NLP response.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct NlpMetadata {
     /// Time it took to generate the response in seconds.
     #[serde(rename(serialize = "generatedIn"))]
@@ -12,21 +12,24 @@ pub struct NlpMetadata {
 
 /// Response from the NLP service for some analysis.
 /// Preserves the order of the input texts.
-/// * `language` field contains the detected languages of the input texts.
-/// * `predicted` field contains the predicted languages of the input texts.
-///
 /// Iterate in lockstep over the two fields to get the corresponding values.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct NlpResponse {
+    /// Classification labels. Indicates the result of the analysis.
     pub labels: Vec<String>,
+    /// Confidence scores for each label. Higher is more confident.
     pub confidences: Vec<f64>,
 }
 
-/// Generic NLP response type.
-/// Contains metadata and a list of analysis results.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Represents a full NLP analysis response.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct NlpAnalysis {
+    /// Kind of analysis performed.
     pub kind: NlpAnalysisKind,
+    /// Metadata for the response.
     pub metadata: NlpMetadata,
+    /// Results of the analysis.
     pub results: Vec<NlpResponse>,
 }

--- a/backend/src/nlp/nlp_response.rs
+++ b/backend/src/nlp/nlp_response.rs
@@ -18,8 +18,8 @@ pub struct NlpMetadata {
 /// Iterate in lockstep over the two fields to get the corresponding values.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NlpResponse {
-    pub label: Vec<String>,
-    pub confidence: Vec<f64>,
+    pub labels: Vec<String>,
+    pub confidences: Vec<f64>,
 }
 
 /// Generic NLP response type.

--- a/backend/src/nlp/nlp_response.rs
+++ b/backend/src/nlp/nlp_response.rs
@@ -1,39 +1,32 @@
-use serde::de::DeserializeOwned;
+use crate::nlp::analysis::NlpAnalysisKind;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-
-/// Private trait used to constrain the types that can be used as the inner type of NlpResponse.
-/// Blanket implemented for all types that implement Serialize, DeserializeOwned, Debug, and Clone.
-pub trait NlpResponseInner: Serialize + DeserializeOwned {}
-
-/// Response from the NLP service for language analysis.
-/// Preserves the order of the input texts.
-/// * `language` field contains the detected languages of the input texts.
-/// * `predicted` field contains the predicted languages of the input texts.
-///
-/// Iterate in lockstep over the two fields to get the language and prediction certainty.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RawLanguageResponse {
-    pub language: Vec<String>,
-    pub predicted: Vec<String>,
-}
-impl NlpResponseInner for RawLanguageResponse {}
 
 /// Metadata for the NLP response.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NlpMetadata {
     /// Time it took to generate the response in seconds.
+    #[serde(rename(serialize = "generatedIn"))]
     pub generated_in: f64,
+}
+
+/// Response from the NLP service for some analysis.
+/// Preserves the order of the input texts.
+/// * `language` field contains the detected languages of the input texts.
+/// * `predicted` field contains the predicted languages of the input texts.
+///
+/// Iterate in lockstep over the two fields to get the corresponding values.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NlpResponse {
+    pub label: Vec<String>,
+    pub confidence: Vec<String>,
 }
 
 /// Generic NLP response type.
 /// Contains metadata and a list of analysis results.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(bound = "T: DeserializeOwned")]
-pub struct NlpResponse<T>
-where
-    T: NlpResponseInner,
-{
+pub struct NlpAnalysis {
+    pub kind: NlpAnalysisKind,
     pub metadata: NlpMetadata,
-    pub results: Vec<T>,
+    pub results: Vec<NlpResponse>,
 }

--- a/backend/src/nlp/report.rs
+++ b/backend/src/nlp/report.rs
@@ -1,16 +1,10 @@
 use crate::api::auth::google::GoogleId;
-use crate::nlp::nlp_response::{NlpResponse, RawLanguageResponse};
+use crate::nlp::analysis::NlpAnalysisKind;
+use crate::nlp::nlp_response::NlpAnalysis;
 use nanoid::nanoid;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt::Debug;
-// /// A trait for a report that can be sent over the WebSocket.
-// /// Used to send reports from the main thread to the WebSocket service.
-// #[typetag::serialize(tag = "type")]
-// pub trait SendableRMoodsReport: Send + DynClone + Debug {
-//     fn metadata(&self) -> &ReportMetadata;
-// }
-// // Macro magic to make it possible to clone Box<dyn SendableRMoodsReport>
-// dyn_clone::clone_trait_object!(SendableRMoodsReport);
 
 /// Metadata for an RMoods report.
 #[derive(Debug, Clone, Serialize)]
@@ -26,23 +20,16 @@ pub struct ReportMetadata {
 pub type ReportId = String;
 
 pub fn new_report_id() -> ReportId {
-    // let alphabet_str = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    // let alphabet = alphabet_str.chars().collect::<Vec<char>>();
     nanoid!(10)
 }
 
 /// An RMoods report.
 ///
 /// Based off of NLP analysis of Reddit feeds.
-/// Contains metadata and a raw response from the NLP service.
+/// Contains metadata and a list of analyses.
 #[derive(Serialize)]
 pub struct RMoodsReport {
     pub id: ReportId,
     pub metadata: ReportMetadata,
-    pub analyses: NlpAnalyses,
-}
-
-#[derive(Serialize)]
-pub struct NlpAnalyses {
-    pub language: Option<NlpResponse<RawLanguageResponse>>,
+    pub analyses: HashMap<NlpAnalysisKind, NlpAnalysis>,
 }

--- a/backend/src/reddit_fetcher/feed_request.rs
+++ b/backend/src/reddit_fetcher/feed_request.rs
@@ -1,3 +1,4 @@
+use crate::nlp::analysis::NlpAnalysisKind;
 use crate::reddit_fetcher::fetcher_error::FetcherError;
 use crate::reddit_fetcher::reddit::request::feed_sorting::FeedSorting;
 use axum::async_trait;
@@ -16,17 +17,6 @@ pub enum RedditFeedKind {
     SubredditPosts,
 }
 
-// TODO: Add more types
-/// What NLP reports do we want to generate?
-#[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum RMoodsReportType {
-    Language,
-    Sentiment,
-    Sarcasm,
-    Etc,
-}
-
 /// Represents a data source for the Reddit API.
 /// It can be a user, a subreddit, or a post.
 ///
@@ -43,13 +33,13 @@ pub struct DataSource {
 }
 
 /// Represents a request to fetch a feed from Reddit.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetcherFeedRequest {
     /// Determines what kind of feed do we fetch and make a report on.
     pub resource_kind: RedditFeedKind,
     /// Determines what NLP reports do we want to generate.
-    pub report_types: Vec<RMoodsReportType>,
+    pub report_types: Vec<NlpAnalysisKind>,
     /// Determines the data sources for the feed.
     pub data_sources: Vec<DataSource>,
     /// Determines how many posts do we want to use to fulfill that report request.
@@ -194,8 +184,8 @@ mod tests {
         assert_eq!(
             feed_request.report_types,
             vec![
-                super::RMoodsReportType::Language,
-                super::RMoodsReportType::Sentiment
+                super::NlpAnalysisKind::Language,
+                super::NlpAnalysisKind::Sentiment
             ]
         );
         assert_eq!(feed_request.data_sources.len(), 2);

--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -135,24 +135,47 @@ app = FastAPI(lifespan=lifespan)
 
 class TextRequest(BaseModel):
     """Request model for text"""
-    text: List[str]
+    text: List[str] = []
 
 
-class Result(BaseModel):
+class AnalysisResult(BaseModel):
     """Result model for text"""
-    label: List[str]
-    confidence: List[float]
+    labels: List[str] = []
+    confidences: List[float] = []
+
+    def __init__(self, labels: List[str], confidences: List[float]):
+        super().__init__()
+        self.labels = labels
+        self.confidences = confidences
 
 
 class Metadata(BaseModel):
     """Metadata model for text"""
-    generated_in: float
+    generated_in: float = 0.0
+
+    def __init__(self, generated_in: float):
+        super().__init__()
+        self.generated_in = generated_in
 
 
 class TextResponse(BaseModel):
     """Response model for text"""
-    metadata: Metadata
-    results: List[Result]
+    kind: str = ""
+    metadata: Metadata = Metadata(generated_in=-1.0)
+    results: List[AnalysisResult] = []
+
+    def __init__(self, kind: str, metadata: Metadata, results: List[AnalysisResult]):
+        super().__init__()
+        self.kind = kind
+        self.metadata = metadata
+        self.results = results
+
+    def json(self):
+        return {
+            "kind": self.kind,
+            "metadata": self.metadata,
+            "results": self.results
+        }
 
 
 @app.post("/sentiment", response_model=TextResponse)
@@ -185,12 +208,17 @@ async def get_sentiment(request: TextRequest):
         probs = output.logits.softmax(dim=-1).tolist()[0]
         confidence = max(probs)
         prediction = probs.index(confidence)
-        text_values = {
-            "label": [labels[prediction]],
-            "confidence": [confidence_output(confidence)]
-        }
-        results.append(text_values)
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+        result = AnalysisResult(
+            labels=[labels[prediction]],
+            confidences=[confidence_output(confidence)]
+        )
+        results.append(result)
+
+    return TextResponse(
+        kind="sentiment",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
 @app.post("/language", response_model=TextResponse)
@@ -219,14 +247,17 @@ async def get_language(request: TextRequest):
             else:
                 languages.append(lang_tag)
 
-        predictions = [confidence_output(y) for y in prediction[1]]
+        result = AnalysisResult(
+            labels=languages,
+            confidences=[confidence_output(y) for y in prediction[1]]
+        )
+        results.append(result)
 
-        text_values = {
-            "label": languages,
-            "confidence": predictions
-        }
-        results.append(text_values)
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+    return TextResponse(
+        kind="language",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
 @app.post("/sarcasm", response_model=TextResponse)
@@ -246,15 +277,20 @@ async def get_sarcasm(request: TextRequest):
         "1": "SARCASTIC"
     }
     results = []
+
     for text in request.text:
         predict = sarcastic_pipeline(text)
-        output = {
-            "label": [labels[predict[0]["label"].replace("LABEL_", "")]],
-            "confidence": [confidence_output(predict[0]["score"])]
-        }
-        results.append(output)
+        result = AnalysisResult(
+            labels=[labels[predict[0]["label"].replace("LABEL_", "")]],
+            confidences=[confidence_output(predict[0]["score"])]
+        )
+        results.append(result)
 
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+    return TextResponse(
+        kind="sarcasm",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
 @app.post("/keywords", response_model=TextResponse)
@@ -274,12 +310,17 @@ async def get_keywords(request: TextRequest):
     results = []
     for text in request.text:
         keywords = keyword_model.extract_keywords(text, top_n=5)
-        output = {
-            "label": [kw[0] for kw in keywords],
-            "confidence": [kw[1] for kw in keywords]
-        }
-        results.append(output)
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+        result = AnalysisResult(
+            labels=[kw[0] for kw in keywords],
+            confidences=[kw[1] for kw in keywords]
+        )
+        results.append(result)
+
+    return TextResponse(
+        kind="keywords",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
 @app.post("/spam", response_model=TextResponse)
@@ -302,13 +343,17 @@ async def get_spam(request: TextRequest):
     results = []
     for text in request.text:
         predict = spam_pipeline(text)
-        output = {
-            "label": [labels[predict[0]["label"].replace("LABEL_", "")]],
-            "confidence": [confidence_output(predict[0]["score"])]
-        }
-        results.append(output)
+        result = AnalysisResult(
+            labels=[labels[predict[0]["label"].replace("LABEL_", "")]],
+            confidences=[confidence_output(predict[0]["score"])]
+        )
+        results.append(result)
 
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+    return TextResponse(
+        kind="spam",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
 @app.post("/politics", response_model=TextResponse)
@@ -328,13 +373,17 @@ async def get_politics(request: TextRequest):
     results = []
     for text in request.text:
         predict = political_pipeline(text)
-        output = {
-            "label": [predict[0]["label"]],
-            "confidence": [confidence_output(predict[0]["score"])]
-        }
-        results.append(output)
+        result = AnalysisResult(
+            labels=[predict[0]["label"]],
+            confidences=[confidence_output(predict[0]["score"])]
+        )
+        results.append(result)
 
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+    return TextResponse(
+        kind="politics",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
 @app.post("/hate-speech", response_model=TextResponse)
@@ -355,13 +404,17 @@ async def get_hate_speech(request: TextRequest):
     results = []
     for text in request.text:
         predict = hate_speech_pipeline(text)
-        output = {
-            "label": [predict[0]["label"]],
-            "confidence": [confidence_output(predict[0]["score"])]
-        }
-        results.append(output)
+        result = AnalysisResult(
+            labels=[predict[0]["label"]],
+            confidences=[confidence_output(predict[0]["score"])]
+        )
+        results.append(result)
 
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+    return TextResponse(
+        kind="hate-speech",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
 @app.post("/clickbait", response_model=TextResponse)
@@ -379,14 +432,20 @@ async def get_clickbait(request: TextRequest):
     results = []
     for text in request.text:
         predict = clickbait_pipeline(text)
-        output = {
-            "label": [predict[0]["label"]],
-            "confidence": [confidence_output(predict[0]["score"])]
-        }
-        results.append(output)
-    return {"metadata": {"generated_in": 0.0}, "results": results}
+        result = AnalysisResult(
+            labels=[predict[0]["label"]],
+            confidences=[confidence_output(predict[0]["score"])]
+        )
+        results.append(result)
+
+    return TextResponse(
+        kind="clickbait",
+        metadata=Metadata(generated_in=0.0),
+        results=results
+    ).json()
 
 
+# TODO: Implement troll model
 @app.post("/troll")
 async def get_troll(request: TextRequest):
     """

--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -411,7 +411,7 @@ async def get_hate_speech(request: TextRequest):
         results.append(result)
 
     return TextResponse(
-        kind="hate-speech",
+        kind="hate_speech",
         metadata=Metadata(generated_in=0.0),
         results=results
     ).json()

--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -135,7 +135,7 @@ app = FastAPI(lifespan=lifespan)
 
 class TextRequest(BaseModel):
     """Request model for text"""
-    text: List[str] = []
+    text: List[str]
 
 
 class AnalysisResult(BaseModel):

--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -171,6 +171,7 @@ class TextResponse(BaseModel):
         self.results = results
 
     def json(self):
+        """Convert object to json"""
         return {
             "kind": self.kind,
             "metadata": self.metadata,
@@ -441,7 +442,7 @@ async def get_clickbait(request: TextRequest):
     return TextResponse(
         kind="clickbait",
         metadata=Metadata(generated_in=0.0),
-        results=results
+        result=results
     ).json()
 
 


### PR DESCRIPTION
This pull request introduces significant changes to the NLP analysis functionality, including the addition of a new enumeration for different types of NLP analyses, refactoring of the NLP client and response handling, and updates to the report generation process. The most important changes are summarized below:

### Refactoring and Enhancements to NLP Analysis:

* [`backend/src/nlp/analysis.rs`](diffhunk://#diff-05d8147d574e02e378dc127b230adfd820667d61f65bbe46317fb339ac610fceR1-R19): Added a new `NlpAnalysisKind` enum to represent different types of NLP analyses, such as language, sentiment, sarcasm, spam, politics, hate speech, clickbait, and keywords.
* [`backend/src/nlp/nlp_client.rs`](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fR2-R18): Refactored the `NlpClient` to use the new `NlpAnalysisKind` enum and updated the `analyze` method to handle different types of analyses. [[1]](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fR2-R18) [[2]](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fR44-R70)
* [`backend/src/nlp/nlp_response.rs`](diffhunk://#diff-1560be9ffcbfef7eb557dbde9a76d278ef7b39b77e0ad86bdf33fab9f63a6e6fL1-R34): Updated the response structure to include a kind of analysis, metadata, and a list of results. Removed the `NlpResponseInner` trait and `RawLanguageResponse` struct.

### Updates to Report Generation:

* [`backend/src/api/report/generate.rs`](diffhunk://#diff-547d3995df89925aa4a90cc8edf49efe05c57993d965f2d4f028a883d3e85ad5L27-R39): Modified the report generation process to use the new `NlpAnalysisKind` enum and updated the structure of the generated reports to use a `HashMap` for storing analyses.
* [`backend/src/nlp/report.rs`](diffhunk://#diff-935b38f70ffa28680057a4ac8c867d8987055560824fdaeb3efe78fa0e1f2831L29-R34): Updated the `RMoodsReport` struct to use a `HashMap` for storing analyses keyed by `NlpAnalysisKind`.

### Error Handling Improvements:

* [`backend/src/nlp/error.rs`](diffhunk://#diff-c516cd410f8088c9aa4ea64c39086f358fabdc4312efebefccf2e001d506d113R3-R9): Added new error variants for handling unexpected responses and communication failures with the NLP service.

### Integration with Other Modules:

* [`backend/src/reddit_fetcher/feed_request.rs`](diffhunk://#diff-48a36580877ea5bb0f78218695a64aecf86507c8d287d51fbf60aa3467aa59adL46-R42): Updated the `FetcherFeedRequest` struct to use the new `NlpAnalysisKind` enum for specifying the types of reports to generate.

### Minor Changes and Cleanup:

* [`backend/src/api/auth/login.rs`](diffhunk://#diff-fc42fe3fdcf9ce4161fa4c3d27152fc3178c0a3d9503ab3b254c961a29b11a6fL49-R49): Simplified error handling in the login function.
* [`nlp/src/main.py`](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L138-R178): Refactored the NLP service endpoints to use the new response structure and added default values for request and response models. [[1]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L138-R178) [[2]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L188-R221) [[3]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L222-R260) [[4]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35R280-R293)