### PR TITLE
181: Add ScrollToTop

### DIFF
--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router-dom';
 import Navbar from './navbar/Navbar.tsx';
 import Footer from './footer/Footer.tsx';
 import { Box, Flex } from '@mantine/core';
+import { ScrollToTop } from '../components/ScrollToTop';
 
 const dashboardFlex = {
   flex: 'auto',
@@ -16,20 +17,23 @@ const dashboardContainer = {
 
 const DashboardLayout = () => {
   return (
-    <Flex>
-      <Sidebar />
-      <Flex
-        // TODO: Cleanup
-        style={{ flex: 'auto', flexDirection: 'column' }}
-        // style={dashboardFlex}
-      >
-        <Navbar />
-        <Box style={dashboardContainer}>
-          <Outlet />
-        </Box>
-        <Footer />
+    <>
+      <Flex>
+        <Sidebar />
+        <Flex
+          // TODO: Cleanup
+          style={{ flex: 'auto', flexDirection: 'column' }}
+          // style={dashboardFlex}
+        >
+          <Navbar />
+          <Box style={dashboardContainer}>
+            <Outlet />
+          </Box>
+          <Footer />
+        </Flex>
       </Flex>
-    </Flex>
+      <ScrollToTop />
+    </>
   );
 };
 

--- a/frontend/src/components/Demo.tsx
+++ b/frontend/src/components/Demo.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Center, Code, Title } from '@mantine/core';
 import { FeedRequest } from '../rmoods/client/types';
 import RMoodsClient from '../rmoods/client/RMoodsClient.ts';
 import LoremIpsum from './LoremIpsum';
+import { ScrollToTop } from '../components/ScrollToTop';
 
 const Demo: React.FC = () => {
   const [reportRes, setReportRes] = useState<object | null>(null);
@@ -40,7 +41,8 @@ const Demo: React.FC = () => {
           <Code>{JSON.stringify(reportRes, null, 2)}</Code>
         </Center>
       </Box>
-      <LoremIpsum n={3} />
+      <LoremIpsum n={20} />
+      <ScrollToTop />
     </>
   );
 };

--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,25 @@
+import { Affix, Button, Transition, rem } from '@mantine/core';
+import { IconArrowUp } from '@tabler/icons-react';
+import { useWindowScroll } from '@mantine/hooks';
+
+export const ScrollToTop = () => {
+  const [scroll, scrollTo] = useWindowScroll();
+
+  return (
+    <Affix position={{ bottom: rem(80), right: rem(20) }}>
+      <Transition transition="slide-up" mounted={scroll.y > 0}>
+        {(transitionStyles) => (
+          <Button
+            style={transitionStyles}
+            onClick={() => scrollTo({ y: 0 })}
+            variant="light"
+            radius="xl"
+            aria-label="Scroll to top"
+          >
+            <IconArrowUp size="1.2rem" />
+          </Button>
+        )}
+      </Transition>
+    </Affix>
+  );
+};


### PR DESCRIPTION
This pull request introduces a new `ScrollToTop` component and integrates it into the `DashboardLayout` and `Demo` components. The most important changes include the creation of the `ScrollToTop` component and its usage in the mentioned components.

### New Feature: ScrollToTop Component

* [`frontend/src/components/ScrollToTop.tsx`](diffhunk://#diff-8037f2a506a407f1d664d174c79eabf9b474d25880a26c39d29316cf9d0b069cR1-R25): Added a new `ScrollToTop` component that uses `Affix`, `Button`, `Transition`, and `useWindowScroll` from `@mantine/core` and `@mantine/hooks` to create a button that scrolls the page to the top when clicked.

### Integration of ScrollToTop Component

* [`frontend/src/components/DashboardLayout.tsx`](diffhunk://#diff-3cd45d97f4cbc1b0d72c687dc98e54b518ecf001fb3ff5513001da5f2fa68b7fR6): Imported the `ScrollToTop` component and included it in the `DashboardLayout` component. [[1]](diffhunk://#diff-3cd45d97f4cbc1b0d72c687dc98e54b518ecf001fb3ff5513001da5f2fa68b7fR6) [[2]](diffhunk://#diff-3cd45d97f4cbc1b0d72c687dc98e54b518ecf001fb3ff5513001da5f2fa68b7fR20) [[3]](diffhunk://#diff-3cd45d97f4cbc1b0d72c687dc98e54b518ecf001fb3ff5513001da5f2fa68b7fR35-R36)
* [`frontend/src/components/Demo.tsx`](diffhunk://#diff-fe7eda624aaf0991a27da6d672d5cf476c0e35f8b84c26ddfa6d61d191b612d1R6): Imported the `ScrollToTop` component and included it in the `Demo` component. Additionally, increased the `LoremIpsum` component's `n` prop from 3 to 20 to provide more content for scrolling. [[1]](diffhunk://#diff-fe7eda624aaf0991a27da6d672d5cf476c0e35f8b84c26ddfa6d61d191b612d1R6) [[2]](diffhunk://#diff-fe7eda624aaf0991a27da6d672d5cf476c0e35f8b84c26ddfa6d61d191b612d1L43-R45)