### PR TITLE
213: Add padding for default and dashboardLayout

### DIFF
--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router-dom';
 import Footer from './components/footer/Footer';
-import { Flex } from '@mantine/core';
+import { Box, Flex } from '@mantine/core';
 import DefaultNavbar from './components/DefaultNavbar.tsx';
 
 const Layout = () => {
@@ -13,7 +13,13 @@ const Layout = () => {
       }}
     >
       <DefaultNavbar />
-      <Outlet />
+      <Box
+        style={{
+          padding: '2rem 2rem',
+        }}
+      >
+        <Outlet />
+      </Box>
       <Footer />
     </Flex>
   );

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -15,7 +15,7 @@ const Layout = () => {
       <DefaultNavbar />
       <Box
         style={{
-          padding: '2rem 2rem',
+          padding: '2rem 15%',
         }}
       >
         <Outlet />

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -13,7 +13,7 @@ const dashboardFlex = {
 const dashboardContainer = {
   marginX: '5%',
   marginY: '2em',
-  padding: '2rem 2rem',
+  padding: '2rem 12%',
 };
 
 const DashboardLayout = () => {

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -13,6 +13,7 @@ const dashboardFlex = {
 const dashboardContainer = {
   marginX: '5%',
   marginY: '2em',
+  padding: '2rem 2rem',
 };
 
 const DashboardLayout = () => {
@@ -22,8 +23,10 @@ const DashboardLayout = () => {
         <Sidebar />
         <Flex
           // TODO: Cleanup
-          style={{ flex: 'auto', flexDirection: 'column' }}
-          // style={dashboardFlex}
+          style={{
+            flex: 'auto',
+            flexDirection: 'column',
+          }}
         >
           <Navbar />
           <Box style={dashboardContainer}>

--- a/frontend/src/components/navbar/UserMenu.tsx
+++ b/frontend/src/components/navbar/UserMenu.tsx
@@ -5,7 +5,7 @@ import authFetch from '../../rmoods/client/authFetch.ts';
 import { useEffect, useState } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { JwtClaims } from '../../rmoods/jwt.ts';
-import { changeDefaultGoogleProfilePicureSize } from '../../utility/changeDefaultGoogleProfilePicureSize.ts';
+import { changeDefaultGoogleProfilePictureSize } from '../../utility/changeDefaultGoogleProfilePictureSize.ts';
 
 /**
  * User interface representing the user data.
@@ -63,7 +63,7 @@ const UserMenu = () => {
 
   const size = 55;
   const resizedPicture = user
-    ? changeDefaultGoogleProfilePicureSize(user.picture, size)
+    ? changeDefaultGoogleProfilePictureSize(user.picture, size)
     : '';
   return (
     <Menu id="user-dropdown">

--- a/frontend/src/routes/user/ProfilePicture.tsx
+++ b/frontend/src/routes/user/ProfilePicture.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Image, Box } from '@mantine/core';
-import { changeDefaultGoogleProfilePicureSize } from '../../utility/changeDefaultGoogleProfilePicureSize.ts';
+import { changeDefaultGoogleProfilePictureSize } from '../../utility/changeDefaultGoogleProfilePictureSize.ts';
 
 /**
  * Props for the ProfilePicture component.
@@ -18,18 +18,24 @@ interface ProfilePictureProps {
  * @returns {JSX.Element} The ProfilePicture component.
  */
 const ProfilePicture: React.FC<ProfilePictureProps> = ({ src, alt }) => {
-  const resizedSrc = changeDefaultGoogleProfilePicureSize(src, 250);
+  const resizedSrc = changeDefaultGoogleProfilePictureSize(src, 250);
 
   return (
-    <Box style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+    <Box
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
       <Image
         src={resizedSrc}
         alt={alt}
         w={'250px'}
         h={'250px'}
-        fit='contain'
-        radius='50%'
-        referrerPolicy='no-referrer'
+        fit="contain"
+        radius="50%"
+        referrerPolicy="no-referrer"
         style={{ objectFit: 'cover', display: 'block' }}
       />
     </Box>

--- a/frontend/src/utility/changeDefaultGoogleProfilePictureSize.ts
+++ b/frontend/src/utility/changeDefaultGoogleProfilePictureSize.ts
@@ -5,10 +5,13 @@
  * @returns {string} The modified URL with the new size.
  * @example
  * // Original URL: https://lh3.googleusercontent.com/a-/AOh14Gg6s9c=s96-c
- * const newUrl = changeDefaultGoogleProfilePicureSize('https://lh3.googleusercontent.com/a-/AOh14Gg6s9c=s96-c', 250);
+ * const newUrl = changeDefaultGoogleProfilePictureSize('https://lh3.googleusercontent.com/a-/AOh14Gg6s9c=s96-c', 250);
  * // newUrl: https://lh3.googleusercontent.com/a-/AOh14Gg6s9c=s250-c
  */
 
-export const changeDefaultGoogleProfilePicureSize = (url: string, newSize: number): string => {
+export const changeDefaultGoogleProfilePictureSize = (
+  url: string,
+  newSize: number
+): string => {
   return url.replace(/s\d+-c/, `s${newSize}-c`);
 };


### PR DESCRIPTION
This pull request includes changes to the layout components in the frontend to improve the padding and styling consistency. The most important changes include adding padding to the `Box` component in `Layout.tsx` and updating the `DashboardLayout` component to include padding and clean up the style definitions. Closes #213.

Styling improvements:

* [`frontend/src/Layout.tsx`](diffhunk://#diff-b9e9bbcc4faf90a2e96cb3a0dae9b19389ca3c0b8c638617aa15990f187dc2a1L3-R3): Imported `Box` from `@mantine/core` and added padding to the `Box` component wrapping the `Outlet`. [[1]](diffhunk://#diff-b9e9bbcc4faf90a2e96cb3a0dae9b19389ca3c0b8c638617aa15990f187dc2a1L3-R3) [[2]](diffhunk://#diff-b9e9bbcc4faf90a2e96cb3a0dae9b19389ca3c0b8c638617aa15990f187dc2a1R16-R22)
* [`frontend/src/components/DashboardLayout.tsx`](diffhunk://#diff-3cd45d97f4cbc1b0d72c687dc98e54b518ecf001fb3ff5513001da5f2fa68b7fR16): Added padding to the `dashboardContainer` style and cleaned up the `Flex` style definitions in the `DashboardLayout` component. [[1]](diffhunk://#diff-3cd45d97f4cbc1b0d72c687dc98e54b518ecf001fb3ff5513001da5f2fa68b7fR16) [[2]](diffhunk://#diff-3cd45d97f4cbc1b0d72c687dc98e54b518ecf001fb3ff5513001da5f2fa68b7fL25-R29)