### PR TITLE
187: Moved WebSocketProvider to router.tsx and commented notification…

### DIFF
--- a/frontend/src/providers/Providers.tsx
+++ b/frontend/src/providers/Providers.tsx
@@ -1,7 +1,6 @@
 import React, { StrictMode } from 'react';
 import { Provider as JotaiProvider, useAtomValue } from 'jotai';
 import { GoogleOAuthProvider } from '@react-oauth/google';
-import WebsocketProvider from './WebsocketProvider.tsx';
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { colorModeAtom } from '../atoms.ts';
@@ -16,11 +15,9 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
         <QueryProvider>
           <MantineProvider defaultColorScheme={colorScheme}>
             <Notifications />
-            <WebsocketProvider>
-              <GoogleOAuthProvider clientId="1055063718392-2ajj0s8h3pol9u5fdlt5vg8jep200r6i.apps.googleusercontent.com">
-                {children}
-              </GoogleOAuthProvider>
-            </WebsocketProvider>
+            <GoogleOAuthProvider clientId="1055063718392-2ajj0s8h3pol9u5fdlt5vg8jep200r6i.apps.googleusercontent.com">
+              {children}
+            </GoogleOAuthProvider>
           </MantineProvider>
         </QueryProvider>
       </JotaiProvider>

--- a/frontend/src/providers/WebsocketProvider.tsx
+++ b/frontend/src/providers/WebsocketProvider.tsx
@@ -5,11 +5,8 @@ import { useEffect, useRef } from 'react';
 import { wsConnectionStatusAtom } from '../atoms.ts';
 
 const WebsocketProvider = ({ children }: { children: React.ReactNode }) => {
-  console.log('WebsocketProvider: rendering');
-
   const connection = useRef<WebSocket | null>(null);
   const [, setWsConnectionStatus] = useAtom(wsConnectionStatusAtom);
-
   useEffect(() => {
     const ws = new WebSocket(
       `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`
@@ -34,12 +31,15 @@ const WebsocketProvider = ({ children }: { children: React.ReactNode }) => {
 
     ws.onerror = (event) => {
       console.error(event);
-      notifications.show({
-        title: 'WebSocket Error',
-        message: 'An error occurred with the WebSocket connection.',
-        color: 'red',
-        icon: '',
-      });
+      // WARNING: this is only commented out for development purposes,
+      // this should be uncommented when deploying
+
+      // notifications.show({
+      //   title: 'WebSocket Error',
+      //   message: 'An error occurred with the WebSocket connection.',
+      //   color: 'red',
+      //   icon: '',
+      // });
       setWsConnectionStatus(false);
     };
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,13 +9,16 @@ import Layout from './Layout';
 import ProtectedRoute from './components/ProtectedRoute';
 import DashboardLayout from './components/DashboardLayout.tsx';
 import Settings from './routes/settings/page.tsx';
+import WebsocketProvider from './providers/WebsocketProvider.tsx';
 
 const router = createBrowserRouter([
   {
     element: (
-      <ProtectedRoute>
-        <DashboardLayout />
-      </ProtectedRoute>
+      <WebsocketProvider>
+        <ProtectedRoute>
+          <DashboardLayout />
+        </ProtectedRoute>
+      </WebsocketProvider>
     ),
     children: [
       {


### PR DESCRIPTION
This pull request includes several changes to the `Providers` component and the handling of the `WebsocketProvider` component in the frontend application. The most important changes involve the removal of the `WebsocketProvider` from the main `Providers` component and its reintroduction in a specific route, as well as some cleanup and commenting out of certain functionalities for development purposes. Closes #187 

Changes to `Providers` component:

* Removed the `WebsocketProvider` import and its usage from the `Providers` component (`frontend/src/providers/Providers.tsx`). [[1]](diffhunk://#diff-abc6e81b02969644b0b4f762ebb0a887b6f4bf25bd3f3f52b326d6cb865a545eL4) [[2]](diffhunk://#diff-abc6e81b02969644b0b4f762ebb0a887b6f4bf25bd3f3f52b326d6cb865a545eL19-L23)

Changes to `WebsocketProvider` component:

* Removed console log and some unnecessary blank lines in the `WebsocketProvider` component (`frontend/src/providers/WebsocketProvider.tsx`).
* Commented out the WebSocket error notification code for development purposes (`frontend/src/providers/WebsocketProvider.tsx`).

Changes to router configuration:

* Added the `WebsocketProvider` around the `ProtectedRoute` in the router configuration (`frontend/src/router.tsx`)