### PR TITLE
212: Put nav items into Group component

### DIFF
--- a/frontend/src/components/DefaultNavbar.tsx
+++ b/frontend/src/components/DefaultNavbar.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Card, Flex, Grid } from '@mantine/core';
+import { Anchor, Card, Flex, Grid, Group } from '@mantine/core';
 import ThemeSwitch from './navbar/ThemeSwitch.tsx';
 
 const LeftNavItems = () => {
@@ -25,20 +25,13 @@ const RightNavItems = () => {
 const DefaultNavbar = () => {
   return (
     <Card
-      style={{ margin: 0, borderRadius: 0, marginBottom: 0, height: '10vh' }}
+      style={{ margin: 0, borderRadius: 0, marginBottom: 0 }}
     >
       <nav>
-        <Grid>
-          <Grid.Col span={4}>
-            <LeftNavItems />
-          </Grid.Col>
-          <Grid.Col span={4}>
-            <div />
-          </Grid.Col>
-          <Grid.Col span={4}>
-            <RightNavItems />
-          </Grid.Col>
-        </Grid>
+        <Group justify='space-between'>
+          <LeftNavItems />
+          <RightNavItems />
+        </Group>
       </nav>
     </Card>
   );

--- a/frontend/src/components/navbar/Navbar.tsx
+++ b/frontend/src/components/navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import UserMenu from './UserMenu';
 import ThemeSwitch from './ThemeSwitch';
-import { Anchor, Card, Flex, Grid } from '@mantine/core';
+import { Anchor, Card, Flex, Group } from '@mantine/core';
 import StatusIndicator from './StatusIndicator';
 import RateLimitStatus from './RateLimitStatus.tsx';
 
@@ -31,20 +31,13 @@ const RightNavItems = () => {
 const Navbar = () => {
   return (
     <Card
-      style={{ margin: 0, borderRadius: 0, marginBottom: 0, height: '10vh' }}
+      style={{ margin: 0, borderRadius: 0, marginBottom: 0 }}
     >
       <nav>
-        <Grid>
-          <Grid.Col span={4}>
-            <LeftNavItems />
-          </Grid.Col>
-          <Grid.Col span={4}>
-            <div />
-          </Grid.Col>
-          <Grid.Col span={4}>
-            <RightNavItems />
-          </Grid.Col>
-        </Grid>
+        <Group justify='space-between'>
+          <LeftNavItems />
+          <RightNavItems />
+        </Group>
       </nav>
     </Card>
   );

--- a/frontend/src/components/sidebar/SidebarNested.module.css
+++ b/frontend/src/components/sidebar/SidebarNested.module.css
@@ -1,14 +1,11 @@
 .navbar {
-  background-color: light-dark(
-    var(--mantine-color-white),
-    var(--mantine-color-dark-6)
-  );
+  background-color: light-dark(var(--mantine-color-white),
+      var(--mantine-color-dark-6));
   padding: var(--mantine-spacing-md);
   padding-bottom: 0;
   display: flex;
   flex-direction: column;
-  border-right: rem(1px) solid
-    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-right: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }
 
 .header {
@@ -18,12 +15,10 @@
   max-height: 10%;
   min-height: 10%;
   padding: var(--mantine-spacing-md);
-  padding-top: 0;
   margin-left: calc(var(--mantine-spacing-sm) * -1);
   margin-right: calc(var(--mantine-spacing-sm) * -1);
   color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-  border-bottom: rem(1px) solid
-    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-bottom: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }
 
 .links {
@@ -40,6 +35,5 @@
 .footer {
   margin-left: calc(var(--mantine-spacing-md) * -1);
   margin-right: calc(var(--mantine-spacing-md) * -1);
-  //border-top: rem(1px) solid
-    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  border-top: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }


### PR DESCRIPTION
This pull request includes changes to the `frontend` components to improve the layout and styling consistency. The most important changes include updating the navigation components to use `Group` instead of `Grid` and cleaning up the CSS in the sidebar component.

### Navigation component updates:
* [`frontend/src/components/DefaultNavbar.tsx`](diffhunk://#diff-d669fa88c53a0445ab4124ae2e0a72cff6e17817a2a5bf4e0de2f134f4829804L1-R1): Replaced `Grid` with `Group` for better layout control and removed unnecessary styling in the `DefaultNavbar` component. [[1]](diffhunk://#diff-d669fa88c53a0445ab4124ae2e0a72cff6e17817a2a5bf4e0de2f134f4829804L1-R1) [[2]](diffhunk://#diff-d669fa88c53a0445ab4124ae2e0a72cff6e17817a2a5bf4e0de2f134f4829804L28-R34)
* [`frontend/src/components/navbar/Navbar.tsx`](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeL3-R3): Similar updates as `DefaultNavbar.tsx`, replacing `Grid` with `Group` and removing unnecessary styling. [[1]](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeL3-R3) [[2]](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeL34-R40)

### Sidebar component CSS cleanup:
* [`frontend/src/components/sidebar/SidebarNested.module.css`](diffhunk://#diff-262bddb10858ee720e74c806a53445df94d21cb504e3ae24debb14caef6ac838L2-R8): Simplified the CSS by combining lines and removing redundant properties. [[1]](diffhunk://#diff-262bddb10858ee720e74c806a53445df94d21cb504e3ae24debb14caef6ac838L2-R8) [[2]](diffhunk://#diff-262bddb10858ee720e74c806a53445df94d21cb504e3ae24debb14caef6ac838L21-R21) [[3]](diffhunk://#diff-262bddb10858ee720e74c806a53445df94d21cb504e3ae24debb14caef6ac838L43-R38)