### PR TITLE
203: add logging

### DIFF
--- a/nlp/README.md
+++ b/nlp/README.md
@@ -24,7 +24,7 @@ To exit the virtual environment, run the following command:
 
 To run the server, run the following command:
 
-```python src/start.py```
+```python start.py```
 
 ### Running the tests
 

--- a/nlp/src/google_service.py
+++ b/nlp/src/google_service.py
@@ -1,5 +1,7 @@
 import pickle
 import os
+
+from src.logger_config import logger
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from google.auth.transport.requests import Request
@@ -21,25 +23,32 @@ def create_service(client_secret_file: str, api_name: str, api_version: str,
     cred = None
     pickle_file = f'token_{api_name}_{api_version}.pickle'
 
+    logger.debug(f"Checking for existing credentials in {pickle_file}")
     if os.path.exists(pickle_file):
         with open(pickle_file, 'rb') as token:
             cred = pickle.load(token)
+            logger.debug("Loaded existing credentials from pickle file")
 
     if not cred or not cred.valid:
+        logger.info("Credentials invalid or missing")
         if cred and cred.expired and cred.refresh_token:
+            logger.debug("Refreshing expired credentials")
             cred.refresh(Request())
         else:
+            logger.debug(f"Creating new credentials flow using {client_secret_file}")
             flow = InstalledAppFlow.from_client_secrets_file(client_secret_file
                                                              , scopes)
             cred = flow.run_local_server(port=8002)
 
+        logger.debug(f"Saving credentials to {pickle_file}")
         with open(pickle_file, 'wb') as token:
             pickle.dump(cred, token)
 
     try:
+        logger.debug(f"Building service for {api_name} {api_version}")
         service = build(api_name, api_version, credentials=cred)
+        logger.info(f"Successfully created {api_name} service")
         return service
     except Exception as e:
-        print('Unable to connect.')
-        print(e)
+        logger.error(f"Failed to connect to {api_name} service: {str(e)}")
         return None

--- a/nlp/src/logger_config.py
+++ b/nlp/src/logger_config.py
@@ -1,0 +1,9 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s:     %(asctime)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger('nlp_service')

--- a/nlp/src/logger_config.py
+++ b/nlp/src/logger_config.py
@@ -1,7 +1,7 @@
 import logging
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.DEBUG,
     format='%(levelname)s:     %(asctime)s - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )

--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -1,6 +1,8 @@
 import src.authorization as auth
 import src.globals as globals
+import logging
 
+from src.logger_config import logger
 from src.base_models import *
 from src.models_loading import *
 from src.utils import *
@@ -20,35 +22,32 @@ async def lifespan(application: FastAPI):
     Args
         application (FastAPI): FastAPI application.
     """
-    print("Application is starting.")
-    print("Checking for model updates.")
-    update_model_versions()
+    logger.info("Application is starting")
+    logger.info("Checking for model updates")
+    try:
+        update_model_versions()
+        logger.debug("Model versions updated successfully")
+    except Exception as e:
+        logger.error(f"Failed to update model versions: {e}")
+        raise
 
-    print("Loading language model.")
-    load_model("language")
+    models = [
+        "language", "sentiment", "sarcasm", "spam",
+        "political", "hate_speech", "clickbait", "keywords"
+    ]
 
-    print("Loading sentiment model.")
-    load_model("sentiment")
+    for model_name in models:
+        logger.info(f"Loading {model_name} model")
+        try:
+            load_model(model_name)
+            logger.debug(f"{model_name.title()} model loaded successfully")
+        except Exception as e:
+            logger.error(f"Failed to load {model_name} model: {e}")
+            raise
 
-    print("Loading sarcastic model.")
-    load_model("sarcasm")
-
-    print("Loading spam model.")
-    load_model("spam")
-    #
-    print("Loading politics model.")
-    load_model("political")
-
-    print("Loadaing hate_speech model.")
-    load_model("hate_speech")
-
-    print("Loading clickbait model.")
-    load_model("clickbait")
-
-    print("Loading keyword model.")
-    load_model("keywords")
+    logger.info("All models loaded successfully")
     yield
-    print("Application is shutting down.")
+    logger.info("Application is shutting down")
 
 app = FastAPI(lifespan=lifespan)
 

--- a/nlp/src/version_checker.py
+++ b/nlp/src/version_checker.py
@@ -3,6 +3,7 @@ import os
 import datetime
 import pytz
 
+from src.logger_config import logger
 from httplib2 import ServerNotFoundError
 from src.google_service import create_service
 from googleapiclient.http import MediaIoBaseDownload, MediaFileUpload
@@ -17,12 +18,12 @@ CROSS_MARK = u'\u274c'
 APPROVAL_MARK = u'\u2705'
 MISSING_MARK = u'\u2753'
 
+
 if os.path.exists("client_secret_file.json"):
     SERVICE = create_service("client_secret_file.json", API_NAME,
                              API_VERSION, SCOPES)
 else:
-    print("client_secret_file.json file not found. Check if the file exists.")
-
+    logger.error("client_secret_file.json file not found. Check if the file exists.")
 
 def read_model_file() -> dict:
     """
@@ -50,10 +51,10 @@ def find_folder(service: object, folder_name: str) -> str:
         if "files" in response and len(response['files']) > 0:
             return response["files"][0]["id"]
     except ServerNotFoundError as e:
-        print(f"Server not found. Stopping looking for folder. {e}")
+        logger.error(f"Server not found. Stopping looking for folder. {e}")
         return ""
     except TimeoutError as e:
-        print(f"Connection timed out. Stopping download. {e}")
+        logger.error(f"Connection timed out. Stopping download. {e}")
         return ""
 
 
@@ -78,10 +79,10 @@ def list_folder_contents(service: object, folder_id: str) -> dict:
                 files[file['name']] = file['id']
         return files
     except ServerNotFoundError as e:
-        print(f"Server not found. Stopping listing files. {e}")
+        logger.error(f"Server not found. Stopping listing files. {e}")
         return {}
     except TimeoutError as e:
-        print(f"Connection timed out. Stopping download. {e}")
+        logger.error(f"Connection timed out. Stopping download. {e}")
         return {}
 
 
@@ -126,10 +127,10 @@ def download_file(service: object, file_id: str, file_name: str,
             f.write(file.read())
 
         if done:
-            print(f"Downloaded {file_name} to {models_directory} successfully.")
+            logger.info(f"Downloaded {file_name} to {models_directory} successfully.")
             return True
     except (HttpError, ServerNotFoundError) as e:
-        print(f"An error occurred: {e}")
+        logger.error(f"An error occurred: {e}")
         return False
 
 
@@ -202,7 +203,7 @@ def get_version(folder_id: str, current_version: str, model_name: str) -> bool:
                         status = download_file(SERVICE, file_id, file_name,
                                                models_directory)
                         if not status:
-                            print(f"An error occurred while downloading the "
+                            logger.error(f"An error occurred while downloading the "
                                   f"file {model_name}.")
                             return False
                 return True
@@ -230,7 +231,7 @@ def update_model_versions(models_names: str = "") -> bool:
         try:
             current_version = data[model_name]
         except KeyError:
-            print(f"Model {model_name} not found in the version_models.json file. "
+            logger.error(f"Model {model_name} not found in the version_models.json file. "
                   f"Check out name of the model file.")
             errors += 1
             continue
@@ -243,7 +244,7 @@ def update_model_versions(models_names: str = "") -> bool:
         download_status = get_version(folder_id, current_version,
                                       model_name)
         if not download_status:
-            print("Error occurred while downloading the file.")
+            logger.error("Error occurred while downloading the file.")
             errors += 1
         else:
             count_correct += 1
@@ -290,7 +291,7 @@ def get_status_information(data: dict, service: object, parent_id: str = 'root',
                 else:
                     file_conditions = APPROVAL_MARK
 
-                print('  ' * level + f"File local: {file}  {file_conditions}")
+                logger.info('  ' * level + f"File local: {file}  {file_conditions}")
 
         for folder in folders:
             skip = False
@@ -309,7 +310,7 @@ def get_status_information(data: dict, service: object, parent_id: str = 'root',
             else:
                 folder_conditions = APPROVAL_MARK
 
-            print('  ' * level + f"Folder local: {folder['name']} "
+            logger.info('  ' * level + f"Folder local: {folder['name']} "
                                  f"  {folder_conditions}")
 
             parent_name = folder['name']
@@ -317,9 +318,9 @@ def get_status_information(data: dict, service: object, parent_id: str = 'root',
                                    folder['name'] + '/', local_status=local_status,
                                    parent_name=parent_name)
     except ServerNotFoundError as e:
-        print(f"Server not found. Stopping listing files. {e}")
+        logger.error(f"Server not found. Stopping listing files. {e}")
     except TimeoutError as e:
-        print(f"Connection timed out. Stopping listing files. {e}")
+        logger.error(f"Connection timed out. Stopping listing files. {e}")
 
 
 def get_status(local_status: bool = False) -> None:
@@ -389,7 +390,7 @@ def upload_file(folder_name: str, version: str, file_name: str) -> bool:
     try:
         file_path = f"models/{folder_name}/{version}/{file_name}"
         if not os.path.exists(file_path):
-            print(f"File {file_name} not found. Stopping upload.")
+            logger.error(f"File {file_name} not found. Stopping upload.")
             return False
 
         folder_id = find_folder(SERVICE, folder_name)
@@ -402,7 +403,7 @@ def upload_file(folder_name: str, version: str, file_name: str) -> bool:
             if file_create == {}:
                 return False
 
-            print(f"File {file_name} uploaded successfully. Model file updated.")
+            logger.info(f"File {file_name} uploaded successfully. Model file updated.")
             return True
 
         query = (f"'{folder_id}' in parents and mimeType='application/"
@@ -430,7 +431,7 @@ def upload_file(folder_name: str, version: str, file_name: str) -> bool:
                     answer = input(f"File {file_name} already exists Do you "
                                    f"want to overwrite the file? (y/n): ")
                     if answer == 'n':
-                        print("File skipped.")
+                        logger.info("File skipped.")
                         return False
                     elif answer == 'y':
                         proceed = True
@@ -447,16 +448,16 @@ def upload_file(folder_name: str, version: str, file_name: str) -> bool:
         if file_create is None:
             return False
 
-        print(f"File {file_name} uploaded successfully. Models file updated.")
+        logger.info(f"File {file_name} uploaded successfully. Models file updated.")
         return True
     except HttpError as e:
-        print(f"An error occurred: {e}")
+        logger.error(f"An error occurred: {e}")
         return False
     except ServerNotFoundError as e:
-        print(f"Server not found. Stopping upload. {e}")
+        logger.error(f"Server not found. Stopping upload. {e}")
         return False
     except TimeoutError as e:
-        print(f"Connection timed out. Stopping upload. {e}")
+        logger.error(f"Connection timed out. Stopping upload. {e}")
         return False
 
 
@@ -476,14 +477,14 @@ def upload_manager(folders: str = None) -> None:
             version = data[folder]
             files = os.listdir(f"models/{folder}/{version}")
             for file_name in files:
-                print(
+                logger.info(
                     f"Uploading {folder} model with version {version}, file {file_name}")
                 update_successful = upload_file(folder, version, file_name)
                 if update_successful == {}:
-                    print(f"File {file_name} already exists. Skipping file.")
+                    logger.warning(f"File {file_name} already exists. Skipping file.")
                 elif not update_successful:
-                    print(f"Error occurred with file {file_name}.")
+                    logger.error(f"Error occurred with file {file_name}.")
         except KeyError:
-            print(f"Model {folder} not found in the version_models.json file. "
+            logger.error(f"Model {folder} not found in the version_models.json file. "
                   f"Check out name of the model")
             

--- a/nlp/start.py
+++ b/nlp/start.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+from src.logger_config import logger
 
 def run_uvicorn():
     port = '8002'
@@ -13,15 +14,14 @@ def run_uvicorn():
         "--port", str(port),
         "--reload"
     ]
-
     try:
         # Run the command
         subprocess.run(command, check=True)
     except subprocess.CalledProcessError as e:
-        print(f"Error running uvicorn: {e}")
+        logger.error(f"Error running uvicorn: {e}")
         sys.exit(1)
     except FileNotFoundError:
-        print("Error: uvicorn not found. Please ensure it is installed and in your PATH")
+        logger.error("Error: uvicorn not found. Please ensure it is installed and in your PATH")
         sys.exit(1)
 
 


### PR DESCRIPTION
This pull request introduces extensive logging improvements across multiple files in the `nlp` project to enhance error tracking and debugging. Additionally, it includes a minor correction to the `README.md` file.

Logging improvements:

* [`nlp/src/logger_config.py`](diffhunk://#diff-d5d4756a5b117c14cc2a90b096d6ae2e9685c108e7714b97617defa428464610R1-R9): Added a new logger configuration to standardize logging across the project.
* [`nlp/src/google_service.py`](diffhunk://#diff-afcb7d30a12162af53c5651bb6fbaa37e583f0624accb97915233b174c6481fbR3-R4): Integrated logging to replace print statements for better tracking of credential management and service creation processes. [[1]](diffhunk://#diff-afcb7d30a12162af53c5651bb6fbaa37e583f0624accb97915233b174c6481fbR3-R4) [[2]](diffhunk://#diff-afcb7d30a12162af53c5651bb6fbaa37e583f0624accb97915233b174c6481fbR26-R53)
* [`nlp/src/main.py`](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L23-R50): Replaced print statements with logger calls in the `lifespan` function to log application startup, model loading, and shutdown processes.
* [`nlp/src/version_checker.py`](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181R21-R26): Added logging to various functions to replace print statements, improving error handling and status reporting for file operations and model version updates. [[1]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181R21-R26) [[2]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L53-R57) [[3]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L129-R133) [[4]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L205-R206) [[5]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L233-R234) [[6]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L246-R247) [[7]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L293-R294) [[8]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L312-R323) [[9]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L392-R393) [[10]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L405-R406) [[11]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L433-R434) [[12]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L450-R460) [[13]](diffhunk://#diff-89b144ca332819d41ba11e40bbc005bce5b965241b66dc4dcd702ae5d82ba181L479-R488)
* [`nlp/start.py`](diffhunk://#diff-c879c26a089baead2ed157b6b089081d61148282464c6fa01d3f72cfbd17ea1aR4): Replaced print statements with logger calls in the `run_uvicorn` function to log errors related to running the server. [[1]](diffhunk://#diff-c879c26a089baead2ed157b6b089081d61148282464c6fa01d3f72cfbd17ea1aR4) [[2]](diffhunk://#diff-c879c26a089baead2ed157b6b089081d61148282464c6fa01d3f72cfbd17ea1aL16-R24)

Documentation correction:

* [`nlp/README.md`](diffhunk://#diff-00ae12f9e23324714a6e056a0290621d58fab5dd7190f1f32bad8c00b880aaa2L27-R27): Corrected the command to run the server by removing the `src/` prefix.