### PR TITLE
229 make all analyses available for reports

### DIFF
--- a/backend/src/api/report/generate.rs
+++ b/backend/src/api/report/generate.rs
@@ -24,12 +24,15 @@ use std::collections::HashMap;
 pub async fn nlp_analysis<T: RedditFeedData>(
     nlp_client: &NlpClient,
     data: T,
+    analysis_kinds: Vec<NlpAnalysisKind>,
     user_id: GoogleId,
 ) -> Result<Report, AppError> {
     let texts = data.extract_texts();
-    let language_analysis = nlp_client
-        .analyze(NlpAnalysisKind::Language, &texts)
-        .await?;
+    let analyses = nlp_client
+        .analyze_parallel(analysis_kinds, &texts)
+        .await?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
     let report = Report {
         id: new_report_id(),
         user_id,
@@ -40,9 +43,7 @@ pub async fn nlp_analysis<T: RedditFeedData>(
             created_at: Utc::now(),
             updated_at: Utc::now(),
         },
-        analyses_map: ReportAnalysesMap {
-            analyses: HashMap::from([(NlpAnalysisKind::Language, language_analysis)]),
-        },
+        analyses_map: ReportAnalysesMap { analyses },
     };
     Ok(report)
 }
@@ -57,8 +58,9 @@ async fn generate_report<T: RedditFeedData>(
     nlp: &NlpClient,
     user_info: &GoogleId,
 ) -> Result<Report, AppError> {
+    let analysis_kinds = feed_request.analyses.clone();
     let (data, _) = fetcher.fetch_feed::<T>(feed_request).await?;
-    let report = nlp_analysis(nlp, data, user_info.clone()).await?;
+    let report = nlp_analysis(nlp, data, analysis_kinds, user_info.clone()).await?;
     Ok(report)
 }
 

--- a/backend/src/nlp/nlp_client.rs
+++ b/backend/src/nlp/nlp_client.rs
@@ -9,6 +9,7 @@ use serde_with::serde_derive::Serialize;
 #[derive(Debug, Clone)]
 pub struct NlpClient {
     nlp_url: String,
+    api_key: String,
     pub http: reqwest::Client,
 }
 
@@ -38,13 +39,14 @@ impl NlpClient {
     pub fn new() -> Self {
         NlpClient {
             nlp_url: std::env::var(NLP_URL).expect("NLP_URL must be set"),
+            api_key: std::env::var(NLP_API_KEY).expect("NLP_API_KEY must be set"),
             http: reqwest::Client::new(),
         }
     }
 
-    fn url_for_analysis(analysis: NlpAnalysisKind) -> &'static str {
+    fn make_url(nlp_url: &str, analysis: NlpAnalysisKind) -> String {
         type A = NlpAnalysisKind;
-        match analysis {
+        let endpoint = match analysis {
             A::Language => "/language",
             A::Sentiment => "/sentiment",
             A::Sarcasm => "/sarcasm",
@@ -53,7 +55,8 @@ impl NlpClient {
             A::HateSpeech => "/hate-speech",
             A::Clickbait => "/clickbait",
             A::Keywords => "/keywords",
-        }
+        };
+        format!("{}{}", nlp_url, endpoint)
     }
 
     #[logfn(err = "ERROR", fmt = "Failed to analyze language: {0:?}")]
@@ -62,26 +65,47 @@ impl NlpClient {
         kind: NlpAnalysisKind,
         input: &Vec<String>,
     ) -> Result<NlpAnalysis, NlpError> {
-        let url = format!("{}{}", self.nlp_url, Self::url_for_analysis(kind));
+        let url = Self::make_url(&self.nlp_url, kind);
 
         log::debug!("Handling only first 10 inputs. Truncating each input to 100 characters.");
         // TODO: Add parallel processing for large inputs, input sampling
-        let request = NlpRequest {
+        let nlp_request = NlpRequest {
             text: truncate_inputs(input, 100),
         };
 
-        log::debug!("Sending request to NLP service: {:?}", request);
-
-        let api_key = std::env::var(NLP_API_KEY).expect("NLP_API_KEY must be set");
+        log::debug!("Sending request to NLP service: {:?}", nlp_request);
 
         let res = self
             .http
-            .post(&url)
-            .json(&request)
-            .header("access_token", api_key)
+            .post(url)
+            .json(&nlp_request)
+            .header("access_token", &self.api_key)
             .send()
             .await?;
+
         Ok(res.json().await?)
+    }
+
+    pub async fn analyze_parallel(
+        &self,
+        analysis_kinds: Vec<NlpAnalysisKind>,
+        input: &Vec<String>,
+    ) -> Result<Vec<(NlpAnalysisKind, NlpAnalysis)>, NlpError> {
+        let futures = analysis_kinds
+            .clone()
+            .into_iter()
+            .map(|kind| self.analyze(kind, input))
+            .collect::<Vec<_>>();
+
+        let analyses = futures::future::join_all(futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(analysis_kinds
+            .into_iter()
+            .zip(analyses.into_iter())
+            .collect())
     }
 }
 

--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -1,17 +1,16 @@
+from contextlib import asynccontextmanager
+
 import src.authorization as auth
 import src.globals as globals
-import logging
-
-from src.logger_config import logger
-from src.base_models import *
-from src.models_loading import *
-from src.utils import *
-from src.version_checker import update_model_versions
 from fastapi import FastAPI, HTTPException
 from fastapi.params import Depends
 from langcodes import tag_is_valid, Language
-from contextlib import asynccontextmanager
-from fastapi.security.api_key import APIKey
+from src.base_models import *
+from src.logger_config import logger
+from src.models_loading import *
+from src.process_input import process_inputs
+from src.utils import *
+from src.version_checker import update_model_versions
 
 
 @asynccontextmanager
@@ -49,6 +48,7 @@ async def lifespan(application: FastAPI):
     yield
     logger.info("Application is shutting down")
 
+
 app = FastAPI(lifespan=lifespan)
 
 
@@ -76,8 +76,7 @@ async def get_sentiment(request: TextRequest):
         5: "Surprise"
     }
 
-    results = []
-    for text in request.text:
+    def process_fn(text):
         tokenized_text = globals.sentiment_tokenizer([preprocess_data(text)],
                                                      padding=True, truncation=True,
                                                      max_length=128, return_tensors="pt")
@@ -89,7 +88,9 @@ async def get_sentiment(request: TextRequest):
             labels=[labels[prediction]],
             confidences=[confidence_output(confidence)]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
         kind="sentiment",
@@ -113,8 +114,7 @@ async def get_language(request: TextRequest):
     if globals.language_model is None:
         raise HTTPException(status_code=500, detail="Model not loaded")
 
-    results = []
-    for text in request.text:
+    def process_fn(text):
         languages = []
         prediction = globals.language_model.predict(text, k=2)
 
@@ -130,7 +130,9 @@ async def get_language(request: TextRequest):
             labels=languages,
             confidences=[confidence_output(y) for y in prediction[1]]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
         kind="language",
@@ -158,15 +160,16 @@ async def get_sarcasm(request: TextRequest):
         "0": "NOT_SARCASTIC",
         "1": "SARCASTIC"
     }
-    results = []
 
-    for text in request.text:
+    def process_fn(text):
         predict = globals.sarcastic_pipeline(text)
         result = AnalysisResult(
             labels=[labels[predict[0]["label"].replace("LABEL_", "")]],
             confidences=[confidence_output(predict[0]["score"])]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
         kind="sarcasm",
@@ -187,19 +190,20 @@ async def get_keywords(request: TextRequest):
     Returns:
         TextResponse: Keyword extraction results with labels and relevance scores.
     """
-    # Rememeber add author if we wan to use this model
+    # Remember add author if we want to use this model
     # How keywords will work with long text?
     if globals.keyword_model is None:
         raise HTTPException(status_code=500, detail="Model not loaded")
 
-    results = []
-    for text in request.text:
+    def process_fn(text):
         keywords = globals.keyword_model.extract_keywords(text, top_n=5)
         result = AnalysisResult(
             labels=[kw[0] for kw in keywords],
             confidences=[kw[1] for kw in keywords]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
         kind="keywords",
@@ -228,14 +232,15 @@ async def get_spam(request: TextRequest):
         "1": "SPAM"
     }
 
-    results = []
-    for text in request.text:
+    def process_fn(text):
         predict = globals.spam_pipeline(text)
         result = AnalysisResult(
             labels=[labels[predict[0]["label"].replace("LABEL_", "")]],
             confidences=[confidence_output(predict[0]["score"])]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
         kind="spam",
@@ -261,14 +266,15 @@ async def get_politics(request: TextRequest):
     if globals.political_pipeline is None:
         raise HTTPException(status_code=500, detail="Model not loaded")
 
-    results = []
-    for text in request.text:
+    def process_fn(text):
         predict = globals.political_pipeline(text)
         result = AnalysisResult(
             labels=[predict[0]["label"]],
             confidences=[confidence_output(predict[0]["score"])]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
         kind="politics",
@@ -295,17 +301,18 @@ async def get_hate_speech(request: TextRequest):
     if globals.hate_speech_pipeline is None:
         raise HTTPException(status_code=500, detail="Model not loaded")
 
-    results = []
-    for text in request.text:
+    def process_fn(text):
         predict = globals.hate_speech_pipeline(text)
         result = AnalysisResult(
             labels=[predict[0]["label"]],
             confidences=[confidence_output(predict[0]["score"])]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
-        kind="hate_speech",
+        kind="hateSpeech",
         metadata=Metadata(generated_in=0.0),
         results=results
     ).json()
@@ -326,19 +333,20 @@ async def get_clickbait(request: TextRequest):
     if globals.clickbait_pipeline is None:
         raise HTTPException(status_code=500, detail="Model not loaded")
 
-    results = []
-    for text in request.text:
+    def process_fn(text):
         predict = globals.clickbait_pipeline(text)
         result = AnalysisResult(
             labels=[predict[0]["label"]],
             confidences=[confidence_output(predict[0]["score"])]
         )
-        results.append(result)
+        return result
+
+    results = process_inputs(process_fn, request.text)
 
     return TextResponse(
         kind="clickbait",
         metadata=Metadata(generated_in=0.0),
-        result=results
+        results=results
     ).json()
 
 

--- a/nlp/src/process_input.py
+++ b/nlp/src/process_input.py
@@ -1,0 +1,17 @@
+import inspect
+from typing import List, Callable
+
+from src.base_models import AnalysisResult
+from src.logger_config import logger
+
+
+def process_inputs(f: Callable[[str], AnalysisResult], texts: List[str]) -> List[AnalysisResult]:
+    """Process input texts."""
+    caller_name = inspect.stack()[1].function
+    results = []
+    for (i, text) in enumerate(texts):
+        logger.info(f"{caller_name}: Processing text {i + 1}/{len(texts)} - {(i + 1) / len(texts) * 100:.2f}%")
+        result = f(text)
+        results.append(result)
+
+    return results


### PR DESCRIPTION
This pull request includes significant changes to the `backend` and `nlp` modules to improve the NLP analysis capabilities and refactor the code for better maintainability. The main changes involve updating the `NlpClient` to support parallel analysis requests and refactoring the input processing functions in the `nlp` module.

### Backend Module Changes:
* [`backend/src/api/report/generate.rs`](diffhunk://#diff-547d3995df89925aa4a90cc8edf49efe05c57993d965f2d4f028a883d3e85ad5R27-R35): Updated the `nlp_analysis` function to accept multiple analysis kinds and perform parallel analysis using the new `analyze_parallel` method. [[1]](diffhunk://#diff-547d3995df89925aa4a90cc8edf49efe05c57993d965f2d4f028a883d3e85ad5R27-R35) [[2]](diffhunk://#diff-547d3995df89925aa4a90cc8edf49efe05c57993d965f2d4f028a883d3e85ad5L43-R46) [[3]](diffhunk://#diff-547d3995df89925aa4a90cc8edf49efe05c57993d965f2d4f028a883d3e85ad5R61-R63)
* [`backend/src/nlp/nlp_client.rs`](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fR12): Added an `api_key` field to `NlpClient` and updated the `analyze` method to use this key. Introduced a new `analyze_parallel` method to handle parallel analysis requests. [[1]](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fR12) [[2]](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fR42-R49) [[3]](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fL56-R59) [[4]](diffhunk://#diff-32b976802056e2b49fcf37727a222d2596ecc5e6c3a076299d7dbcd47a5a710fL65-R109)

### NLP Module Changes:
* [`nlp/src/main.py`](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35R1-L14): Refactored multiple analysis functions (`get_sentiment`, `get_language`, `get_sarcasm`, `get_keywords`, `get_spam`, `get_politics`, `get_hate_speech`, and `get_clickbait`) to use a new `process_inputs` helper function for better code reuse and maintainability. [[1]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35R1-L14) [[2]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35R51) [[3]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L79-R79) [[4]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L92-R93) [[5]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L116-R117) [[6]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L133-R135) [[7]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L161-R172) [[8]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L190-R206) [[9]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L231-R243) [[10]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L264-R277) [[11]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L298-R315) [[12]](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35L329-R349)