### PR TITLE
226 build and push nlp docker image   gh action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+name: NLP Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: nlp
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build NLP image
+        run: |
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-${{ github.ref_name }} .
+
+      - name: Push NLP image
+        run: |
+          docker push ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-${{ github.ref_name }}

--- a/.github/workflows/nlp.yml
+++ b/.github/workflows/nlp.yml
@@ -5,6 +5,8 @@ on:
     branches: ["**"]
   pull_request:
     branches: ["**"]
+  release:
+    types: [published]
 
 jobs:
   docker:
@@ -24,8 +26,8 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-0.6.0 .
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-${{ vars.RELEASE_TAG }} .
 
       - name: Push image
         run: |
-          docker push ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-0.6.0
+          docker push ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-${{ vars.RELEASE_TAG }}

--- a/.github/workflows/nlp.yml
+++ b/.github/workflows/nlp.yml
@@ -1,33 +1,32 @@
-name: Python NLP
+name: Python NLP Tests
 
 on:
   push:
     branches: ["**"]
   pull_request:
     branches: ["**"]
-  release:
-    types: [published]
-
 jobs:
-  docker:
+  test:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: nlp
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          python-version: "3.12"
+          cache: "pip"
 
-      - name: Build image
+      - name: Install NLP dependencies
         run: |
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-${{ vars.RELEASE_TAG }} .
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-      - name: Push image
-        run: |
-          docker push ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-${{ vars.RELEASE_TAG }}
+      - name: Set environment variables
+        run: echo "NLP_API_KEY=valid_api_key" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/nlp.yml
+++ b/.github/workflows/nlp.yml
@@ -7,27 +7,25 @@ on:
     branches: ["**"]
 
 jobs:
-  test:
+  docker:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: nlp
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
-          python-version: "3.12"
-          cache: 'pip'
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Install NLP dependencies
+      - name: Build image
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      
-      - name: Set environment variables
-        run: echo "NLP_API_KEY=valid_api_key" >> $GITHUB_ENV
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-0.6.0 .
 
-      - name: Run tests
-        run: pytest
+      - name: Push image
+        run: |
+          docker push ${{ secrets.DOCKER_USERNAME }}/rmoods:nlp-0.6.0


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to build and test the NLP Docker image and run Python NLP tests. The most important changes are the addition of a new workflow for building and pushing the NLP Docker image and modifications to the existing NLP test workflow.

### GitHub Actions Workflows:

* Added a new workflow for building and pushing the NLP Docker image on release. This includes steps for checking out the repository, logging into DockerHub, building the Docker image, and pushing the image to DockerHub. (`.github/workflows/docker.yml`)
* Renamed the existing workflow to "Python NLP Tests" for clarity. (`.github/workflows/nlp.yml`)
* Minor change to use double quotes consistently for the `cache` attribute in the Python setup step. (`.github/workflows/nlp.yml`)