### PR TITLE
273: Sidebar links work only on the text instead of the whole element

### DIFF
--- a/frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.module.scss
+++ b/frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.module.scss
@@ -43,3 +43,8 @@
     height: var(--mantine-icon-size-md);
     width: var(--mantine-icon-size-md);
 }
+
+.onlyLink {
+  text-decoration: none;
+  color: var(--mantine-color-text);
+}

--- a/frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.tsx
+++ b/frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.tsx
@@ -83,20 +83,18 @@ export function SidebarEntry({
 
   if (link) {
     return (
-      <UnstyledButton className={classes.control}>
-        <Link to={link} className={classes.onlyLink}>
-          <Group justify="space-between" gap={0}>
-            <Flex className={classes.entryFlex}>
-              <ThemeIcon variant="light" size={30}>
-                <Icon className={classes.icon} />
-              </ThemeIcon>
-              <Box ml="md">
-                <Text>{label}</Text>
-              </Box>
-            </Flex>
-          </Group>
-        </Link>
-      </UnstyledButton>
+      <Link to={link} className={`${classes.onlyLink} ${classes.control}`}>
+        <Group justify="space-between" gap={0}>
+          <Flex className={classes.entryFlex}>
+            <ThemeIcon variant="light" size={30}>
+              <Icon className={classes.icon} />
+            </ThemeIcon>
+            <Box ml="md">
+              <Text>{label}</Text>
+            </Box>
+          </Flex>
+        </Group>
+      </Link>
     );
   } else {
     return (

--- a/frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.tsx
+++ b/frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.tsx
@@ -84,18 +84,18 @@ export function SidebarEntry({
   if (link) {
     return (
       <UnstyledButton className={classes.control}>
-        <Group justify="space-between" gap={0}>
-          <Flex className={classes.entryFlex}>
-            <ThemeIcon variant="light" size={30}>
-              <Icon className={classes.icon} />
-            </ThemeIcon>
-            <Box ml="md">
-              <Text component={Link} to={link}>
-                {label}
-              </Text>
-            </Box>
-          </Flex>
-        </Group>
+        <Link to={link} className={classes.onlyLink}>
+          <Group justify="space-between" gap={0}>
+            <Flex className={classes.entryFlex}>
+              <ThemeIcon variant="light" size={30}>
+                <Icon className={classes.icon} />
+              </ThemeIcon>
+              <Box ml="md">
+                <Text>{label}</Text>
+              </Box>
+            </Flex>
+          </Group>
+        </Link>
       </UnstyledButton>
     );
   } else {


### PR DESCRIPTION
This pull request includes changes to the `SidebarLinksGroup` component to improve the styling and structure of sidebar links in the dashboard layout. The most important changes include adding a new CSS class for styling links and updating the `SidebarEntry` function to use this new class.

Styling improvements:

* [`frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.module.scss`](diffhunk://#diff-cbefa63af59d338bce82985d8b96727d4a7b2bf8380c690c3cd40cd9168d9967R46-R50): Added a new CSS class `.onlyLink` to remove text decoration and set the text color.

Code structure updates:

* [`frontend/src/layouts/dashboard/sidebar/SidebarLinksGroup.tsx`](diffhunk://#diff-f0d13d5e0abaf5acad7560115f0ecf52fe7b16cccc4aa10306b2c6eb1c2ac03eR87-R98): Updated the `SidebarEntry` function to wrap the `Group` component with a `Link` component and apply the new `.onlyLink` class. This change simplifies the structure and ensures consistent styling.