### PR TITLE
276: Add check for NLP_API_KEY env var

### DIFF
--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -14,6 +14,7 @@ pub fn verify_environment() -> bool {
         GOOGLE_CLIENT_ID,
         GOOGLE_CLIENT_SECRET,
         NLP_URL,
+        NLP_API_KEY,
     ];
     let defined: Vec<String> = std::env::vars().map(|(k, _)| k).collect();
 


### PR DESCRIPTION
This pull request includes a change to the `backend/src/startup.rs` file to ensure that the `NLP_API_KEY` environment variable is verified during the startup process.

* [`backend/src/startup.rs`](diffhunk://#diff-519ca40eacd1b4e517214b34b9772d6a440aa8a3fef28bacbbed97c70ed3796eR17): Added `NLP_API_KEY` to the list of environment variables that need to be verified in the `verify_environment` function.