### PR TITLE
278: Add time measure for each classification

### DIFF
--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -1,5 +1,6 @@
 import src.authorization as auth
 import src.globals as globals
+import time
 
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
@@ -91,11 +92,13 @@ async def get_sentiment(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="sentiment",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 
@@ -133,11 +136,13 @@ async def get_language(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="language",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 
@@ -170,11 +175,13 @@ async def get_sarcasm(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="sarcasm",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 
@@ -204,11 +211,13 @@ async def get_keywords(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="keywords",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 
@@ -241,11 +250,13 @@ async def get_spam(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="spam",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 
@@ -275,11 +286,13 @@ async def get_politics(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="politics",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 
@@ -315,7 +328,7 @@ async def get_hate_speech(request: TextRequest):
         return lang_tag
 
     def process_fn(text):
-        lang_name= detect_language(text)
+        lang_name = detect_language(text)
         if lang_name == "Polish":
             predict = globals.hate_speech_polish_pipeline(text)
         else:
@@ -327,11 +340,13 @@ async def get_hate_speech(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="hateSpeech",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 
@@ -359,11 +374,13 @@ async def get_clickbait(request: TextRequest):
         )
         return result
 
+    start_generation = time.time()
     results = process_inputs(process_fn, request.text)
+    generation_time = round(time.time() - start_generation, 2)
 
     return TextResponse(
         kind="clickbait",
-        metadata=Metadata(generated_in=0.0),
+        metadata=Metadata(generated_in=generation_time),
         results=results
     ).json()
 

--- a/nlp/src/main.py
+++ b/nlp/src/main.py
@@ -92,9 +92,7 @@ async def get_sentiment(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="sentiment",
@@ -136,9 +134,7 @@ async def get_language(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="language",
@@ -175,9 +171,7 @@ async def get_sarcasm(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="sarcasm",
@@ -211,9 +205,7 @@ async def get_keywords(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="keywords",
@@ -250,9 +242,7 @@ async def get_spam(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="spam",
@@ -286,9 +276,7 @@ async def get_politics(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="politics",
@@ -340,9 +328,7 @@ async def get_hate_speech(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="hateSpeech",
@@ -374,9 +360,7 @@ async def get_clickbait(request: TextRequest):
         )
         return result
 
-    start_generation = time.time()
-    results = process_inputs(process_fn, request.text)
-    generation_time = round(time.time() - start_generation, 2)
+    results, generation_time = measure_execution_time(lambda: process_inputs(process_fn, request.text))
 
     return TextResponse(
         kind="clickbait",

--- a/nlp/src/utils.py
+++ b/nlp/src/utils.py
@@ -1,5 +1,6 @@
 import string
 import json
+import time
 
 def preprocess_data(input_text: str):
     """
@@ -35,3 +36,21 @@ def read_model_file() -> dict:
     """
     with open("version_models.json", "r") as f:
         return json.load(f)
+
+
+def measure_execution_time(func) -> tuple:
+    """
+    Measure the execution time of a function.
+
+    Args:
+        func (function): Function to measure the execution time.
+
+    Returns:
+        tuple: Tuple with the results of the function and the execution time.
+    """
+    start_time = time.time()
+    results = func()
+    end_time = time.time()
+    execution_time = round(end_time - start_time,2)
+
+    return (results, execution_time)


### PR DESCRIPTION
This pull request includes changes to the `nlp/src/main.py` file to add generation time metadata to the responses of various text processing functions. The most important changes include importing the `time` module and updating multiple `process_fn` functions to calculate and include the generation time in the metadata.

### Changes to add generation time metadata:

* [`nlp/src/main.py`](diffhunk://#diff-9494eb851ef1146f005648d9703f5c0e73e4c9b8a4380fdf089541fe5e3a7e35R3): Imported the `time` module to enable time tracking.
* Updated `process_fn` functions to calculate and include generation time in the metadata for various text processing tasks:
  * Sentiment analysis
  * Language detection
  * Sarcasm detection
  * Keyword extraction
  * Spam detection
  * Politics detection
  * Hate speech detection
  * Clickbait detection