### PR TITLE
272: Fix report query ignoring visibility, add new option for query

### DIFF
--- a/backend/src/api/report/get.rs
+++ b/backend/src/api/report/get.rs
@@ -1,4 +1,5 @@
 use crate::app_error::AppError;
+use crate::auth::google::JwtUserInfo;
 use crate::db::impls::report_repository::{ReportQuery, ReportRepository};
 use crate::nlp::report::Report;
 use crate::AppState;
@@ -11,9 +12,10 @@ use log_derive::logfn;
 pub async fn get_reports(
     State(state): State<AppState>,
     Query(query): Query<ReportQuery>,
+    user_info: JwtUserInfo,
 ) -> Result<Json<Vec<Report>>, AppError> {
     log::debug!("Getting reports by query: {:?}", query);
-    let reports = Report::get_by_query(query, &state.db).await?;
+    let reports = Report::get_by_query(query, user_info.id, &state.db).await?;
     log::debug!("Returning {:?} reports", reports.len());
     Ok(Json(reports))
 }

--- a/backend/src/db/impls/report_repository.rs
+++ b/backend/src/db/impls/report_repository.rs
@@ -1,3 +1,4 @@
+use crate::auth::google::GoogleId;
 use crate::db::db_client::DbClient;
 use crate::db::from_db::FromDb;
 use crate::db::model::DbReport;
@@ -52,6 +53,11 @@ pub struct ReportQuery {
     /// The query will return reports where the title contains this string. It's used as `LIKE %<pattern>%`.
     #[serde(rename = "title")]
     pub title_pattern: Option<String>,
+
+    /// Whether include reports belonging to the requesting user.
+    #[serde(rename = "mine")]
+    pub include_my_reports: bool,
+
     /// Pagination parameters for the query.
     ///
     /// If not provided, the default values are used: page 1, 30 items per page.
@@ -67,6 +73,7 @@ impl Default for ReportQuery {
             start_date: None,
             end_date: None,
             title_pattern: None,
+            include_my_reports: false,
             pagination: DbPagination::default(),
         }
     }
@@ -111,6 +118,8 @@ struct ReportQueryBindArgs {
     ///
     /// If not provided in the query, it's an empty string. It's used as `LIKE %<pattern>%`.
     title_pattern: String,
+    /// Whether to only fetch reports belonging to the requesting user.
+    include_my_reports: bool,
 }
 
 impl ReportQuery {
@@ -122,7 +131,7 @@ impl ReportQuery {
     /// For example, if the username pattern is not provided, it's an empty string, which will match any username.
     /// Another example: the date range, where if it's not provided, the start date is the UNIX epoch and the end date is the current date and time, which will match any report.
     fn into_bind_args(self) -> ReportQueryBindArgs {
-        let user_name_pattern = self.user_name_pattern.unwrap_or(String::new());
+        let user_name_pattern = self.user_name_pattern.unwrap_or("".to_string());
         let contained_analysis_kinds_clauses = if self.contained_analysis_kinds.is_empty() {
             "1=1".to_string()
         } else {
@@ -150,6 +159,7 @@ impl ReportQuery {
             start_date,
             end_date,
             title_pattern,
+            include_my_reports: self.include_my_reports,
         }
     }
 }
@@ -159,7 +169,11 @@ impl ReportQuery {
 /// Specifies methods for fetching reports from the database.
 #[async_trait]
 pub trait ReportRepository: Sized {
-    async fn get_by_query(query: ReportQuery, db: &DbClient) -> Result<Vec<Self>, Error>;
+    async fn get_by_query(
+        query: ReportQuery,
+        requesting_user_id: GoogleId,
+        db: &DbClient,
+    ) -> Result<Vec<Self>, Error>;
 }
 
 #[async_trait]
@@ -176,7 +190,11 @@ impl ReportRepository for Report {
     /// It's safe, because the kinds are passed as a [Vec] of [NlpAnalysisKind]s, which are validated by `serde` deserialization.
     ///
     /// **Any changes to this function need to be carefully reviewed to prevent SQL injection.**
-    async fn get_by_query(query: ReportQuery, db: &DbClient) -> Result<Vec<Self>, Error> {
+    async fn get_by_query(
+        query: ReportQuery,
+        requesting_user_id: GoogleId,
+        db: &DbClient,
+    ) -> Result<Vec<Self>, Error> {
         let (limit, offset) = query.pagination.clone().into_limit_and_offset();
 
         let bind_args = query.into_bind_args();
@@ -192,7 +210,8 @@ impl ReportRepository for Report {
         AND rm.report_created_at >= $2 AND rm.report_created_at <= $3
         AND {}
         AND r.title LIKE '%$4%'
-        LIMIT $5 OFFSET $6
+        AND (r.is_public = TRUE OR (u.google_sub = $5 AND $6))
+        LIMIT $7 OFFSET $8
         "#,
             bind_args.contained_analysis_kinds_clauses
         );
@@ -202,6 +221,8 @@ impl ReportRepository for Report {
             .bind(bind_args.start_date)
             .bind(bind_args.end_date)
             .bind(bind_args.title_pattern)
+            .bind(requesting_user_id)
+            .bind(bind_args.include_my_reports)
             .bind(limit)
             .bind(offset)
             .fetch_all(db.raw_db())
@@ -333,8 +354,10 @@ mod tests {
                 start_date: None,
                 end_date: None,
                 title_pattern: None,
+                include_my_reports: false,
                 pagination: DbPagination::default(),
             },
+            GoogleId::from("test".to_string()),
             &db,
         )
         .await
@@ -357,8 +380,10 @@ mod tests {
                 start_date: Some(Utc::now() - chrono::Duration::days(3)),
                 end_date: Some(Utc::now()),
                 title_pattern: Some("test".to_string()),
+                include_my_reports: true,
                 pagination: DbPagination::new(0, 10),
             },
+            GoogleId::from("test".to_string()),
             &db,
         )
         .await


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality of the report querying system by incorporating user-specific filters and authentication. The key updates include adding user information to the report query, modifying the database query to include user-specific conditions, and updating the tests to reflect these changes.

Enhancements to report querying:

* [`backend/src/api/report/get.rs`](diffhunk://#diff-252924602d15959721cfcd43da4ce1c141e0c2b202f5dbad529e9d3a0779d6ecR2): Introduced `JwtUserInfo` to the `get_reports` function to include user information in the query. [[1]](diffhunk://#diff-252924602d15959721cfcd43da4ce1c141e0c2b202f5dbad529e9d3a0779d6ecR2) [[2]](diffhunk://#diff-252924602d15959721cfcd43da4ce1c141e0c2b202f5dbad529e9d3a0779d6ecR15-R18)

Database query modifications:

* [`backend/src/db/impls/report_repository.rs`](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR1): Added `GoogleId` to the imports and included `include_my_reports` in the `ReportQuery` struct to filter reports based on the requesting user. [[1]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR1) [[2]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR56-R60) [[3]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR76) [[4]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR121-R122) [[5]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dL125-R134) [[6]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR162)
* [`backend/src/db/impls/report_repository.rs`](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dL162-R176): Updated the `ReportRepository` trait and its implementation to accept `requesting_user_id` and apply user-specific conditions in the SQL query. [[1]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dL162-R176) [[2]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dL179-R197) [[3]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dL195-R214) [[4]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR224-R225)

Test updates:

* [`backend/src/db/impls/report_repository.rs`](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR357-R360): Modified the test cases to include `GoogleId` and `include_my_reports` to validate the new functionality. [[1]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR357-R360) [[2]](diffhunk://#diff-ccb88790a57d74524f7fcb73d0ccf6821603a1cfb3352f96a23c73d19586984dR383-R386)…ng user's own reports