### PR TITLE
258 invalidate a report form with no nlp analyses requested

### DIFF
--- a/backend/src/fetcher/feed_request.rs
+++ b/backend/src/fetcher/feed_request.rs
@@ -59,6 +59,7 @@ impl FetcherFeedRequest {
     /// * Post IDs should only contain alphanumeric characters.
     /// * All data sources for PostComments should have a `post_id`.
     /// * No data sources for UserPosts and SubredditPosts should have a `post_id`.
+    /// * At least one analysis has to be requested.
     #[logfn(err = "ERROR", fmt = "Failed to validate feed request: {0}")]
     pub fn validate(&self) -> Result<(), FetcherError> {
         // Check if there are any data sources
@@ -125,6 +126,13 @@ impl FetcherFeedRequest {
                         .to_string(),
                 ));
             }
+        }
+
+        // Check if at least one analysis has been requested
+        if self.analyses.is_empty() {
+            return Err(FetcherError::InvalidFeedRequest(
+                "At least one analysis has to be requested".to_string(),
+            ));
         }
 
         Ok(())
@@ -303,6 +311,13 @@ mod tests {
                 share: 50,
             },
         ];
+        assert!(feed_request.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_feed_request_no_analyses() {
+        let mut feed_request = testing_request();
+        feed_request.analyses.clear();
         assert!(feed_request.validate().is_err());
     }
 }

--- a/frontend/src/routes/report/page.tsx
+++ b/frontend/src/routes/report/page.tsx
@@ -16,7 +16,12 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useEffect, useState } from 'react';
-import { DataSource, ReportFormValidationSchema, ReportFormValues, RowWrapper } from './schema.ts';
+import {
+  DataSource,
+  ReportFormValidationSchema,
+  ReportFormValues,
+  RowWrapper,
+} from './schema.ts';
 import { zodResolver } from 'mantine-form-zod-resolver';
 import { DataSourceTable } from './DataSourceTable.tsx';
 import { transformJson } from './transformJson.ts';
@@ -361,6 +366,15 @@ const Report = () => {
                   })}
                 />
               </Stack>
+              {form.errors.analyses && ( // Display the error message
+                <Input.Error
+                  style={() => ({
+                    marginTop: '6px',
+                  })}
+                >
+                  {form.errors.analyses}
+                </Input.Error>
+              )}
             </Stack>
           </Card>
 

--- a/frontend/src/routes/report/page/page.module.scss
+++ b/frontend/src/routes/report/page/page.module.scss
@@ -1,0 +1,3 @@
+.error {
+  margin-top: 6px;
+}

--- a/frontend/src/routes/report/page/page.tsx
+++ b/frontend/src/routes/report/page/page.tsx
@@ -21,14 +21,15 @@ import {
   ReportFormValidationSchema,
   ReportFormValues,
   RowWrapper,
-} from './schema.ts';
+} from '../schema.ts';
 import { zodResolver } from 'mantine-form-zod-resolver';
-import { DataSourceTable } from './DataSourceTable.tsx';
-import { transformJson } from './transformJson.ts';
-import { RMoodsClient } from '../../rmoods/client/RMoodsClient.ts';
+import { DataSourceTable } from '../DataSourceTable.tsx';
+import { transformJson } from '../transformJson.ts';
+import { RMoodsClient } from '../../../rmoods/client/RMoodsClient.ts';
 import { ErrorBoundary } from 'react-error-boundary';
-import { PageFallback } from '../PageFallback.tsx';
+import { PageFallback } from '../../PageFallback.tsx';
 import { IconLock, IconWorld } from '@tabler/icons-react';
+import classes from './page.module.scss';
 
 /**
  * Report component for creating a new report.
@@ -207,11 +208,7 @@ const Report = () => {
                 />
               </Box>
               {form.errors.dataSources && (
-                <Input.Error
-                  style={() => ({
-                    marginTop: '6px',
-                  })}
-                >
+                <Input.Error className={classes.error}>
                   {form.errors.dataSources}
                 </Input.Error>
               )}
@@ -367,11 +364,7 @@ const Report = () => {
                 />
               </Stack>
               {form.errors.analyses && ( // Display the error message
-                <Input.Error
-                  style={() => ({
-                    marginTop: '6px',
-                  })}
-                >
+                <Input.Error className={classes.error}>
                   {form.errors.analyses}
                 </Input.Error>
               )}

--- a/frontend/src/routes/report/schema.ts
+++ b/frontend/src/routes/report/schema.ts
@@ -13,16 +13,23 @@ export const FeedKindSchema = z.enum([
   'postComments',
 ]);
 
-export const AnalysisTypeSchema = z.object({
-  language: z.boolean(),
-  sentiment: z.boolean(),
-  sarcasm: z.boolean(),
-  spam: z.boolean(),
-  politics: z.boolean(),
-  hateSpeech: z.boolean(),
-  clickbait: z.boolean(),
-  trolling: z.boolean(),
-});
+export const AnalysisTypeSchema = z
+  .object({
+    language: z.boolean(),
+    sentiment: z.boolean(),
+    sarcasm: z.boolean(),
+    spam: z.boolean(),
+    politics: z.boolean(),
+    hateSpeech: z.boolean(),
+    clickbait: z.boolean(),
+    trolling: z.boolean(),
+  })
+  .refine(
+    (value) => {
+      return Object.values(value).some((val) => val === true);
+    },
+    { message: 'At least 1 analysis type is required' }
+  );
 
 export const FeedSortingKindSchema = z.enum([
   'hot',

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -4,7 +4,7 @@ import Dashboard from './dashboard/page.tsx';
 import Login from './login/page.tsx';
 import Root from './page.tsx';
 import UserPage from './user/page.tsx';
-import Report from './report/page.tsx';
+import Report from './report/page/page.tsx';
 import Layout from '../layouts/standard/layout/Layout.tsx';
 import ProtectedRoute from './ProtectedRoute.tsx';
 import DashboardLayout from '../layouts/dashboard/layout/DashboardLayout.tsx';


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend of the application to ensure that at least one analysis type is requested in feed requests. The most important changes include adding validation logic to the backend, updating the frontend to display error messages, and modifying the schema to enforce this requirement.

### Backend changes:

* [`backend/src/fetcher/feed_request.rs`](diffhunk://#diff-7f1e50901cacf555e21ce48f7c0202e37cf54a8e9949ebd33726ddb70bac29a1R62): Added a validation check to ensure at least one analysis is requested in `validate` method of `FetcherFeedRequest` and updated corresponding comments. [[1]](diffhunk://#diff-7f1e50901cacf555e21ce48f7c0202e37cf54a8e9949ebd33726ddb70bac29a1R62) [[2]](diffhunk://#diff-7f1e50901cacf555e21ce48f7c0202e37cf54a8e9949ebd33726ddb70bac29a1R131-R137)
* [`backend/src/fetcher/feed_request.rs`](diffhunk://#diff-7f1e50901cacf555e21ce48f7c0202e37cf54a8e9949ebd33726ddb70bac29a1R316-R322): Added a test case `test_validate_feed_request_no_analyses` to verify the new validation logic.

### Frontend changes:

* [`frontend/src/routes/report/page.tsx`](diffhunk://#diff-b722d95d00ff9785960608af6ac880f7c9f6658e22757f609e9733b84d2d250bL19-R24): Updated import statements for better readability.
* [`frontend/src/routes/report/page.tsx`](diffhunk://#diff-b722d95d00ff9785960608af6ac880f7c9f6658e22757f609e9733b84d2d250bR369-R377): Added error message display for missing analysis types in the `Report` component.
* [`frontend/src/routes/report/schema.ts`](diffhunk://#diff-8b3755c76024d7a47f0a07a6612093d9596f946cfc80ae8a5b3828abc0703740L16-R17): Modified `AnalysisTypeSchema` to include a refinement that ensures at least one analysis type is selected. [[1]](diffhunk://#diff-8b3755c76024d7a47f0a07a6612093d9596f946cfc80ae8a5b3828abc0703740L16-R17) [[2]](diffhunk://#diff-8b3755c76024d7a47f0a07a6612093d9596f946cfc80ae8a5b3828abc0703740L25-R32)