### PR TITLE
263: Write down styling standards

### DIFF
--- a/frontend/styling-standards.md
+++ b/frontend/styling-standards.md
@@ -1,50 +1,93 @@
-# Styling standards
-This file contains the styling  standards for the project's frontend.
+# Frontend Styling Standards
 
-## CSS preprocessor and postprocessor
-We have to remember that we use preprocessor and postprocessor (Sass and PostCSS). That means that module files should end in `.scss` and not `.css`. We also have a few predefined functions (src/_mantine.scss)
+## Core Configuration
 
-## No inline styles
-Using `styles` prop is not allowed. Any CSS style that is applied to a component should be a defined prop in the component's documentation. See next section for how to style components.
+### Preprocessor Setup
+- **Primary**: Sass (`.scss`)
+- **Secondary**: PostCSS
+- **Utility Functions**: Available in `src/_mantine.scss`
 
-## Module CSS
-Any CSS written should be in a module file next to the `.tsx` file. Those two files should be contained in a directory with the same name so an example structure would be:
+## File Structure
 ```
-src/
-  components/
-    Button/
-      Button.tsx
-      Button.module.scss
+component/  
+├── ComponentName/  
+│   ├── ComponentName.tsx  
+│   └── ComponentName.module.scss
+```
+## Routes Structure
+```
+routes/  
+├── routeName/  
+│   └── page.tsx  
+└── ui/  
+  └── ComponentName/  
+  ├── ComponentName.tsx  
+  └── ComponentName.module.scss  
 ```
 
-## Naming conventions
-As we are using CSS modules, we don't need to worry about class name collisions. We should stick to KISS principle and use simple class names. Names should be a single word, lowercase and using camelCase in case of multiple words. For example:
+## Implementation Guidelines
+
+### CSS Modules
+```typescript jsx
+// ComponentName.tsx
+import classes from './ComponentName.module.scss';
+
+export function ComponentName() {
+  return <Box className={classes.container}>...</Box>;
+}
+// ComponentName.module.scss
+.container {
+// styles
+}
+```
+### Class Naming
 ```css
-.button {
-  background-color: red;
-}
+// ✅ Correct
+.container {}
+.buttonPrimary {}
+.navItem {}
 
-.buttonPrimary {
-  background-color: blue;
-}
+// ❌ Incorrect
+.Container {}
+.button-primary {}
+.nav_item {}
 ```
 
-## Importing CSS
-When importing `.module.scss` file in a `.tsx` file, the import should look like this:
-```tsx
-import classes from './Button.module.scss';
+### Styling Hierarchy
+
+- CSS Modules (Preferred)
+- Mantine Props (For basic properties or non-obvious styling)
+- Inline Styles (Prohibited)
+
+### Mantine Usage
+```typescript jsx
+// ✅ Correct (only if the prop has a specified name in the component's documentation)
+<Button gap='md'/>
+
+// ❌ Incorrect
+<Button styles={{ root: { backgroundColor: 'blue' }}} />
 ```
 
-## Structure in `/routes` direcrory
-In `/routes` directory components that are related to the route but are not the page itself have to be in a `/ui` directory. For example:
+## Technical Requirements
+
+### File Extensions
+Every style file should end with `.module.scss`
+
+### Import Conventions
 ```
-src/
-  routes/
-    login/
-      page.tsx
-    ui/
-      Button/
-      Button.tsx
-      Button.module.scss
+// Every styles import should be named 'classes'
+import classes from './ComponentName.module.scss';
 ```
 
+### Module Resolution
+
+- All style modules must be typed
+- Use relative paths for component-specific imports
+- Use absolute paths for shared resources
+
+## Prohibited Practices
+- Direct usage of .css files
+- Inline styles via style prop
+- Non-modular CSS
+- Global styles (except for root-level configuration)
+- Style prop usage in Mantine components

--- a/frontend/styling-standards.md
+++ b/frontend/styling-standards.md
@@ -3,31 +3,47 @@
 ## Core Configuration
 
 ### Preprocessor Setup
+
 - **Primary**: Sass (`.scss`)
 - **Secondary**: PostCSS
 - **Utility Functions**: Available in `src/_mantine.scss`
 
 ## File Structure
+
+In general, a component's implementation is structured like so:
+
 ```
-component/  
-├── ComponentName/  
-│   ├── ComponentName.tsx  
-│   └── ComponentName.module.scss
+ComponentName/  
+├── ComponentName.tsx  
+├── ComponentName.module.scss
+└── ComponentFallback.tsx
 ```
+
+It contains a `.tsx` file along with `.module.scss` for styling, all inside a directory named like the component in
+question, but using camelCase.
+In some cases, it also contains a fallback component in case an error is thrown while rendering.
+
 ## Routes Structure
+
+When some components are needed to implement a route and are not used just in one place, you can separate them out to
+the `ui` directory inside the route directory.
+
 ```
 routes/  
-├── routeName/  
-│   └── page.tsx  
-└── ui/  
-  └── ComponentName/  
-  ├── ComponentName.tsx  
-  └── ComponentName.module.scss  
+└── routeName/  
+    ├── page.tsx  
+    └── ui/  
+        └── ComponentName/  
+            ├── ComponentName.tsx  
+            └── ComponentName.module.scss  
 ```
 
 ## Implementation Guidelines
 
-### CSS Modules
+### SCSS Modules
+
+SCSS Modules are used to scope styles locally by default, preventing style conflicts:
+
 ```typescript jsx
 // ComponentName.tsx
 import classes from './ComponentName.module.scss';
@@ -35,48 +51,82 @@ import classes from './ComponentName.module.scss';
 export function ComponentName() {
   return <Box className={classes.container}>...</Box>;
 }
+
+
 // ComponentName.module.scss
-.container {
-// styles
+.
+container
+{
+  // styles
 }
 ```
+
 ### Class Naming
+
+All classes must be named in camelCase
+
 ```css
-// ✅ Correct
-.container {}
-.buttonPrimary {}
-.navItem {}
+✅ Correct
+.container {
+}
+
+.buttonPrimary {
+}
+
+.navItem {
+}
+
+
+❌ Incorrect
+.Container {
+}
+
+.button-primary {
+}
+
+.nav_item {
+}
+```
+
+### Mantine Usage
+
+Mantine is our framework of choice, and it contains some useful props. However only the props listed in the component's
+Props section in Mantine docs can be used.
+For example: https://mantine.dev/core/textarea/?t=props
+
+All props listed there can be used. That leaves props such as `w`, `h`, `flex` etc. as prohibited, as they can be easily
+emulated using SCSS.
+
+```typescript jsx
+// ✅ Correct (only if the prop has a specified name in the component's documentation)
+<Button gap='md' />
 
 // ❌ Incorrect
-.Container {}
-.button-primary {}
-.nav_item {}
+<Button styles={{ root: { backgroundColor: 'blue' } }} />
 ```
 
 ### Styling Hierarchy
 
-- CSS Modules (Preferred)
-- Mantine Props (For basic properties or non-obvious styling)
+- Mantine Props (Only if listed in docs)
+- SCSS Modules (Preferred)
 - Inline Styles (Prohibited)
-
-### Mantine Usage
-```typescript jsx
-// ✅ Correct (only if the prop has a specified name in the component's documentation)
-<Button gap='md'/>
-
-// ❌ Incorrect
-<Button styles={{ root: { backgroundColor: 'blue' }}} />
-```
 
 ## Technical Requirements
 
 ### File Extensions
+
 Every style file should end with `.module.scss`
 
 ### Import Conventions
+
+Every styles import should be named 'classes'
+
 ```
-// Every styles import should be named 'classes'
+// ✅ Correct 
 import classes from './ComponentName.module.scss';
+
+// ❌ Incorrect
+import styles from './ComponentName.module.scss';
 ```
 
 ### Module Resolution
@@ -86,6 +136,7 @@ import classes from './ComponentName.module.scss';
 - Use absolute paths for shared resources
 
 ## Prohibited Practices
+
 - Direct usage of .css files
 - Inline styles via style prop
 - Non-modular CSS

--- a/frontend/styling-standards.md
+++ b/frontend/styling-standards.md
@@ -1,0 +1,50 @@
+# Styling standards
+This file contains the styling  standards for the project's frontend.
+
+## CSS preprocessor and postprocessor
+We have to remember that we use preprocessor and postprocessor (Sass and PostCSS). That means that module files should end in `.scss` and not `.css`. We also have a few predefined functions (src/_mantine.scss)
+
+## No inline styles
+Using `styles` prop is not allowed. Any CSS style that is applied to a component should be a defined prop in the component's documentation. See next section for how to style components.
+
+## Module CSS
+Any CSS written should be in a module file next to the `.tsx` file. Those two files should be contained in a directory with the same name so an example structure would be:
+```
+src/
+  components/
+    Button/
+      Button.tsx
+      Button.module.scss
+```
+
+## Naming conventions
+As we are using CSS modules, we don't need to worry about class name collisions. We should stick to KISS principle and use simple class names. Names should be a single word, lowercase and using camelCase in case of multiple words. For example:
+```css
+.button {
+  background-color: red;
+}
+
+.buttonPrimary {
+  background-color: blue;
+}
+```
+
+## Importing CSS
+When importing `.module.scss` file in a `.tsx` file, the import should look like this:
+```tsx
+import classes from './Button.module.scss';
+```
+
+## Structure in `/routes` direcrory
+In `/routes` directory components that are related to the route but are not the page itself have to be in a `/ui` directory. For example:
+```
+src/
+  routes/
+    login/
+      page.tsx
+    ui/
+      Button/
+      Button.tsx
+      Button.module.scss
+```
+


### PR DESCRIPTION
This pull request introduces a new file, `frontend/styling-standards.md`, which outlines the styling standards for the project's frontend. The document includes guidelines on the use of CSS preprocessors, module CSS, naming conventions, and directory structure.

Styling standards documentation:

* Added a new file `frontend/styling-standards.md` to document the styling standards for the frontend. This includes guidelines on using Sass and PostCSS, avoiding inline styles, organizing module CSS files, naming conventions, and importing CSS in `.tsx` files.
* Defined the structure for components within the `/routes` directory, specifying that components related to the route but not the page itself should be placed in a `/ui` directory.