### PR TITLE
301: Serial tests to fix flakiness

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "serial_test",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2123,6 +2124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b13f8ea6177672c49d12ed964cca44836f59621981b04a3e26b87e675181de"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2146,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
 
 [[package]]
 name = "security-framework"
@@ -2252,6 +2268,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -37,3 +37,4 @@ nanoid = "0.4.0"
 uuid = { version = "1.11.0", features = ["v4"] }
 axum-extra = { version = "0.9.6", features = ["query"] }
 once_cell = "1.20.2"
+serial_test = "3.2.0"

--- a/backend/src/fetcher/tests.rs
+++ b/backend/src/fetcher/tests.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::fetcher::model::subreddit_info::SubredditAbout;
     use crate::fetcher::model::user_info::UserAbout;
     use crate::fetcher::reddit::request::{SubredditAboutRequest, UserAboutRequest};
+    use lazy_static::lazy_static;
     use reqwest::{Client, ClientBuilder};
 
     fn random_string(len: usize) -> String {
@@ -17,63 +18,50 @@ mod tests {
             .collect()
     }
 
-    use once_cell::sync::OnceCell;
-    use tokio::sync::Mutex;
+    use serial_test::serial;
 
-    static HTTP: OnceCell<Client> = OnceCell::new();
-    static FETCHER: OnceCell<Mutex<RMoodsFetcher>> = OnceCell::new();
-
-    fn get_http() -> &'static Client {
-        HTTP.get_or_init(|| ClientBuilder::new().user_agent("RMoods").build().unwrap())
+    lazy_static! {
+        static ref HTTP: Client = ClientBuilder::new().user_agent("RMoods").build().unwrap();
     }
 
-    async fn get_fetcher() -> &'static Mutex<RMoodsFetcher> {
-        if let Some(fetcher) = FETCHER.get() {
-            return fetcher;
-        }
-
+    async fn get_fetcher() -> RMoodsFetcher {
         dotenvy::dotenv().ok();
-        let http = get_http();
-        let fetcher = Mutex::new(RMoodsFetcher::new(http.clone()).await.unwrap());
-        FETCHER.set(fetcher).ok();
-        FETCHER.get().unwrap()
+        RMoodsFetcher::new(HTTP.clone()).await.unwrap()
     }
 
     #[tokio::test]
+    #[serial]
     async fn fetch_about_user() {
-        let fetcher = get_fetcher().await;
-        let mut fetcher_lock = fetcher.lock().await;
+        let mut fetcher = get_fetcher().await;
 
         let request = UserAboutRequest {
             username: "spez".to_string(),
         };
-        let user = fetcher_lock
-            .fetch_about::<UserAbout>(request)
-            .await
-            .unwrap();
+        let user = fetcher.fetch_about::<UserAbout>(request).await.unwrap();
         assert_eq!(user.info.name, "spez");
     }
 
     #[tokio::test]
+    #[serial]
     async fn fetch_about_nonexistent_user() {
-        let fetcher = get_fetcher().await;
-        let mut fetcher_lock = fetcher.lock().await;
+        let mut fetcher = get_fetcher().await;
 
         let request = UserAboutRequest {
             username: random_string(20),
         };
-        let user = fetcher_lock.fetch_about::<UserAbout>(request).await;
+        let user = fetcher.fetch_about::<UserAbout>(request).await;
         assert!(user.is_err());
     }
 
     #[tokio::test]
+    #[serial]
     async fn fetch_about_subreddit() {
-        let fetcher = get_fetcher().await;
-        let mut fetcher_lock = fetcher.lock().await;
+        let mut fetcher = get_fetcher().await;
+
         let request = SubredditAboutRequest {
             subreddit: "programming".to_string(),
         };
-        let sub = fetcher_lock
+        let sub = fetcher
             .fetch_about::<SubredditAbout>(request)
             .await
             .unwrap();
@@ -81,13 +69,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn fetch_about_nonexistent_subreddit() {
-        let fetcher = get_fetcher().await;
-        let mut fetcher_lock = fetcher.lock().await;
+        let mut fetcher = get_fetcher().await;
+
         let request = SubredditAboutRequest {
             subreddit: random_string(20),
         };
-        let sub = fetcher_lock.fetch_about::<SubredditAbout>(request).await;
+        let sub = fetcher.fetch_about::<SubredditAbout>(request).await;
         assert!(sub.is_err());
     }
     // TODO: Feed fetching tests


### PR DESCRIPTION
This pull request includes changes to improve the testing setup in the `backend` project by replacing `once_cell` with `lazy_static` and `serial_test`. The key changes are:

Testing improvements:

* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1R40): Added `serial_test` dependency to the project.
* [`backend/src/fetcher/tests.rs`](diffhunk://#diff-b8af26c01b9c426512adba5bb64f2c4a512f64388f9af0f6a3c8148e67b61e27R7): Imported `lazy_static` for static initialization.
* [`backend/src/fetcher/tests.rs`](diffhunk://#diff-b8af26c01b9c426512adba5bb64f2c4a512f64388f9af0f6a3c8148e67b61e27L20-R79): Replaced `once_cell` with `lazy_static` for static `Client` initialization and simplified the `get_fetcher` function.
* [`backend/src/fetcher/tests.rs`](diffhunk://#diff-b8af26c01b9c426512adba5bb64f2c4a512f64388f9af0f6a3c8148e67b61e27L20-R79): Added `serial` attribute to test functions to ensure they run serially.