### PR TITLE
262 switch to usewebsocket

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "react-error-boundary": "^4.1.2",
         "react-icons": "^5.3.0",
         "react-router-dom": "^6.26.2",
+        "react-use-websocket": "^4.11.1",
         "recharts": "^2.13.3",
         "zod": "^3.23.8"
       },
@@ -6117,6 +6118,12 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/react-use-websocket": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.11.1.tgz",
+      "integrity": "sha512-39e8mK2a2A1h8uY3ePF45b2q0vwMOmaEy7J5qEhQg4n7vYa5oDLmqutG36kZQgAQ/3KCZS0brlGRbbZJ0+zfKQ==",
+      "license": "MIT"
     },
     "node_modules/recharts": {
       "version": "2.13.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "react-error-boundary": "^4.1.2",
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.2",
+    "react-use-websocket": "^4.11.1",
     "recharts": "^2.13.3",
     "zod": "^3.23.8"
   },

--- a/frontend/src/layouts/dashboard/navbar/userMenu/UserMenu.module.scss
+++ b/frontend/src/layouts/dashboard/navbar/userMenu/UserMenu.module.scss
@@ -1,3 +1,3 @@
 .avatar {
-  cursor: default;
+  cursor: pointer;
 }

--- a/frontend/src/providers/WebsocketProvider.tsx
+++ b/frontend/src/providers/WebsocketProvider.tsx
@@ -1,47 +1,55 @@
 import Cookies from 'js-cookie';
 import { useAtom } from 'jotai';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { wsConnectionStatusAtom } from '../atoms.ts';
 import { handleMessage } from '../routes/report/websocketMethods.tsx';
+import useWebSocket from 'react-use-websocket';
+import { notifications } from '@mantine/notifications';
+
+/**
+ * This component establishes a WebSocket connection to the server and provides
+ * WebSocket functionality to its child components.
+ * 
+ * @param {Object} props - The component props
+ * @param {React.ReactNode} props.children - The child components to render within the provider
+ * @returns {JSX.Element} The WebsocketProvider component.
+ */
 
 const WebsocketProvider = ({ children }: { children: React.ReactNode }) => {
-  const connection = useRef<WebSocket | null>(null);
   const [, setWsConnectionStatus] = useAtom(wsConnectionStatusAtom);
+
+  const { sendMessage, lastMessage, readyState } = useWebSocket(
+    `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`,
+    {
+      onOpen: () => {
+        console.log('WebSocket connection opened.');
+        setWsConnectionStatus(true);
+      },
+      onClose: () => {
+        console.log('WebSocket connection closed.');
+        setWsConnectionStatus(false);
+      },
+      onError: (event) => {
+        console.error('WebSocket error:.', event);
+        // WARNING: this is only commented out for development purposes,
+        // this should be uncommented when deploying
+        // notifications.show({
+        //   title: 'WebSocket Error',
+        //   message: 'An error occurred with the WebSocket connection.',
+        //   color: 'red',
+        //   icon: '',
+        // });
+        setWsConnectionStatus(false);
+      },
+      shouldReconnect: () => true,
+    }
+  );
+
   useEffect(() => {
-    const ws = new WebSocket(
-      `ws://localhost:8001/ws/connect?RMOODS_JWT=${Cookies.get('RMOODS_JWT')}`
-    );
-
-    ws.onmessage = handleMessage;
-
-    ws.onopen = () => {
-      console.log('WebSocket connection opened.');
-      setWsConnectionStatus(true);
-    };
-
-    ws.onerror = (event) => {
-      console.error(event);
-      // WARNING: this is only commented out for development purposes,
-      // this should be uncommented when deploying
-
-      // notifications.show({
-      //   title: 'WebSocket Error',
-      //   message: 'An error occurred with the WebSocket connection.',
-      //   color: 'red',
-      //   icon: '',
-      // });
-      setWsConnectionStatus(false);
-    };
-
-    ws.onclose = () => {
-      setWsConnectionStatus(false);
-    };
-
-    connection.current = ws;
-    return () => {
-      ws.close();
-    };
-  }, []);
+    if (lastMessage !== null) {
+      handleMessage(lastMessage);
+    }
+  }, [lastMessage]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
This pull request includes several updates to the frontend codebase, focusing on adding a new WebSocket library, updating the user menu cursor style, and modifying the WebSocket provider component to use the new library.

### Library Updates:
* Added `react-use-websocket` library to `frontend/package.json` and `frontend/package-lock.json` to manage WebSocket connections more efficiently. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R43) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR33) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR6122-R6127)

### Style Changes:
* Changed the cursor style of the `.avatar` class in `UserMenu.module.scss` from `default` to `pointer` to improve user experience. It was so annoying seeing a default cursor.

### WebSocket Provider Refactor:
* Refactored `WebsocketProvider.tsx` to use the `react-use-websocket` library for handling WebSocket connections, including adding comments for better code documentation and removing the manual WebSocket connection management.