### PR TITLE
315: Update backend dependencies

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,17 +143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,15 +165,15 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "async-trait",
  "axum-core",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -216,10 +192,10 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower 0.5.1",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -227,11 +203,10 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
 dependencies = [
- "async-trait",
  "bytes",
  "futures-util",
  "http",
@@ -240,7 +215,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -248,37 +223,37 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
- "fastrand",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
  "serde",
  "serde_html_form",
- "tower 0.5.1",
+ "serde_path_to_error",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -367,9 +342,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -408,6 +383,15 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -534,7 +518,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -556,7 +540,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -588,13 +572,13 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6433aac097572ea8ccc60b3f2e756c661c9aeed9225cdd4d0cb119cb7ff6ba"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -605,7 +589,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -628,7 +612,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -707,9 +691,14 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -743,6 +732,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -835,7 +830,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -924,37 +919,29 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1099,7 +1086,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1282,11 +1268,10 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1308,6 +1293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1364,12 +1355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,23 +1373,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -1431,16 +1399,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1507,27 +1465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,7 +1502,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1585,6 +1522,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1610,12 +1553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,26 +1576,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1715,93 +1632,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
-dependencies = [
- "bytes",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
-dependencies = [
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1890,7 +1726,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1910,24 +1745,19 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pemfile",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "windows-registry",
 ]
 
@@ -1966,7 +1796,6 @@ dependencies = [
  "log",
  "log-derive",
  "nanoid",
- "once_cell",
  "rand",
  "reqwest",
  "serde",
@@ -1974,7 +1803,7 @@ dependencies = [
  "serde_with",
  "serial_test",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.10",
  "tokio",
  "tokio-util",
  "tower-http",
@@ -2023,7 +1852,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.85",
+ "syn 2.0.96",
  "walkdir",
 ]
 
@@ -2042,12 +1871,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
@@ -2069,7 +1892,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2193,7 +2015,7 @@ checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2270,7 +2092,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2295,7 +2117,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2346,6 +2168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,7 +2181,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.65",
  "time",
 ]
 
@@ -2371,6 +2199,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2402,20 +2233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2426,38 +2247,32 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
 dependencies = [
- "ahash",
- "atoi",
- "byteorder",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown 0.15.0",
  "hashlink",
- "hex",
  "indexmap 2.6.0",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "thiserror",
+ "thiserror 2.0.10",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2467,22 +2282,22 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
 dependencies = [
  "dotenvy",
  "either",
@@ -2498,7 +2313,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
+ "syn 2.0.96",
  "tempfile",
  "tokio",
  "url",
@@ -2506,12 +2321,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -2542,7 +2357,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.10",
  "tracing",
  "uuid",
  "whoami",
@@ -2550,12 +2365,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "chrono",
@@ -2564,7 +2379,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -2582,7 +2396,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.10",
  "tracing",
  "uuid",
  "whoami",
@@ -2590,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
 dependencies = [
  "atoi",
  "chrono",
@@ -2606,10 +2420,10 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
  "tracing",
  "url",
- "urlencoding",
  "uuid",
 ]
 
@@ -2655,20 +2469,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -2719,7 +2527,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+dependencies = [
+ "thiserror-impl 2.0.10",
 ]
 
 [[package]]
@@ -2730,7 +2547,18 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2805,7 +2633,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2842,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
 dependencies = [
  "futures-util",
  "log",
@@ -2866,47 +2694,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
-dependencies = [
- "indexmap 2.6.0",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2915,12 +2711,12 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "async-compression",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags",
  "bytes",
  "futures-core",
@@ -2937,7 +2733,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2976,7 +2772,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2996,9 +2792,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
 dependencies = [
  "byteorder",
  "bytes",
@@ -3008,7 +2804,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 2.0.10",
  "utf-8",
 ]
 
@@ -3052,18 +2848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,12 +2865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,9 +2878,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
  "indexmap 2.6.0",
  "serde",
@@ -3112,27 +2890,26 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "7.1.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943e0ff606c6d57d410fd5663a4d7c074ab2c5f14ab903b9514565e59fa1189e"
+checksum = "040cad8bd8de63f3d028e08e5b39be49d68f8a646e99f4aea2e2d4d82c34b21f"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
- "reqwest",
  "rust-embed",
  "serde",
  "serde_json",
@@ -3215,7 +2992,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -3249,7 +3026,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3268,15 +3045,6 @@ checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -3486,15 +3254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,7 +3271,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3523,9 +3282,9 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"
-version = "1.1.4"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -3533,8 +3292,23 @@ dependencies = [
  "displaydoc",
  "flate2",
  "indexmap 2.6.0",
- "num_enum",
- "thiserror",
+ "memchr",
+ "thiserror 2.0.10",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,23 +8,23 @@ opt-level = 1
 
 [dependencies]
 tokio = { version = "1.37.0", features = ["full"] }
-axum = { version = "0.7.5", features = ["ws", "macros"] }
+axum = { version = "0.8.1", features = ["ws", "macros"] }
 env_logger = "0.11.3"
 log = "0.4.21"
 serde = "1.0.203"
 serde_json = "1.0.117"
-tower-http = { version = "0.5.2", features = ["full"] }
-utoipa = { version = "4.2.3", features = ["axum_extras", "chrono"] }
-utoipa-swagger-ui = { version = "7", features = ["axum"] }
+tower-http = { version = "0.6.2", features = ["full"] }
+utoipa = { version = "5.3.1", features = ["axum_extras", "chrono"] }
+utoipa-swagger-ui = { version = "8.1.1", features = ["axum"] }
 lazy_static = "1.5.0"
 anyhow = "1.0.86"
 reqwest = { version = "0.12.5", features = ["json", "multipart"] }
-derive-getters = "0.4.0"
-thiserror = "1.0.62"
+derive-getters = "0.5.0"
+thiserror = "2.0.10"
 serde_with = "3.8.3"
 log-derive = "0.4.1"
 dotenvy = "0.15.7"
-sqlx = { version = "0.7", features = ["runtime-tokio", "postgres", "macros", "json", "chrono", "uuid", "migrate"] }
+sqlx = { version = "0.8.3", features = ["runtime-tokio", "postgres", "macros", "json", "chrono", "uuid", "migrate"] }
 jsonwebtoken = "9.3.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 http = "1.1.0"
@@ -35,6 +35,5 @@ http-serde = "2.1.1"
 rand = "0.8.5"
 nanoid = "0.4.0"
 uuid = { version = "1.11.0", features = ["v4"] }
-axum-extra = { version = "0.9.6", features = ["query"] }
-once_cell = "1.20.2"
+axum-extra = { version = "0.10.0", features = ["query"] }
 serial_test = "3.2.0"

--- a/backend/src/api/about/subreddit.rs
+++ b/backend/src/api/about/subreddit.rs
@@ -5,7 +5,6 @@ use crate::AppState;
 use axum::extract::State;
 use axum::Json;
 
-#[utoipa::path(get, path = "/api/about/subreddit", responses(), params())]
 pub async fn subreddit_about(
     State(mut state): State<AppState>,
     Json(request): Json<SubredditAboutRequest>,

--- a/backend/src/api/about/user.rs
+++ b/backend/src/api/about/user.rs
@@ -5,7 +5,6 @@ use crate::AppState;
 use axum::extract::State;
 use axum::Json;
 
-#[utoipa::path(get, path = "/api/about/user", responses(), params())]
 pub async fn user_about(
     State(mut state): State<AppState>,
     Json(request): Json<UserAboutRequest>,

--- a/backend/src/auth/google.rs
+++ b/backend/src/auth/google.rs
@@ -2,7 +2,6 @@ use crate::auth::error::AuthError;
 use crate::auth::jwt::decode_jwt;
 use crate::auth::middleware::jwt_from_header_or_uri;
 use crate::auth::user::{GoogleId, User};
-use axum::async_trait;
 use axum::extract::FromRequestParts;
 use derive_getters::Getters;
 use http::request::Parts;
@@ -10,6 +9,7 @@ use http::StatusCode;
 use log_derive::logfn;
 use reqwest::{multipart::Form, Client};
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 
 #[derive(Deserialize, Debug, Getters)]
 pub struct GoogleTokenResponse {
@@ -30,8 +30,7 @@ pub struct JwtUserInfo {
 ///
 /// With this trait implemented, the user info can be extracted by any Axum HTTP handler without
 /// jumping through extra hoops like obtaining an `Authorization` header and decoding the JWT.
-#[async_trait]
-impl<T> FromRequestParts<T> for JwtUserInfo {
+impl<T: Send + Sync> FromRequestParts<T> for JwtUserInfo {
     type Rejection = StatusCode;
 
     async fn from_request_parts(parts: &mut Parts, _: &T) -> Result<Self, Self::Rejection> {

--- a/backend/src/db/db_stored.rs
+++ b/backend/src/db/db_stored.rs
@@ -1,7 +1,6 @@
 use crate::db::db_client::DbClient;
 use crate::db::db_error::DbError;
 use crate::db::pagination::DbPagination;
-use axum::async_trait;
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
@@ -55,7 +54,6 @@ impl<T> DbStored for T where T: DbStoredInner {}
 ///
 /// As opposed to the [DbStored](crate::db::db_stored::DbStored) trait, this one has concrete implementations
 /// for top-level types - [Report](crate::report::report::Report) and [User](crate::auth::user::User).
-#[async_trait]
 pub(super) trait DbStoredInner: Sized {
     /// Saves the object to the database using the provided transaction.
     async fn inner_save(&self, tx: &mut Transaction<Postgres>) -> Result<(), DbError>;
@@ -74,7 +72,6 @@ pub(super) trait DbStoredInner: Sized {
 /// Internal trait for database-stored objects that depend on other objects.
 ///
 /// This is used for objects that are referenced by other objects.
-#[async_trait]
 pub(super) trait DbStoredDependentlyInner: Sized {
     async fn inner_save(
         &self,

--- a/backend/src/db/from_db.rs
+++ b/backend/src/db/from_db.rs
@@ -1,9 +1,7 @@
 use crate::db::db_error::DbError;
-use axum::async_trait;
 use sqlx::PgPool;
 
 /// Trait for converting a database model to the corresponding domain type, i.e. Rust struct.
-#[async_trait]
 pub(super) trait FromDb: Sized {
     type DbModel;
     async fn from_db_model(model: Self::DbModel, pool: &PgPool) -> Result<Self, DbError>;

--- a/backend/src/db/impls/data_request.rs
+++ b/backend/src/db/impls/data_request.rs
@@ -5,7 +5,6 @@ use crate::db::model::{DbDataRequest, DbDataSource};
 use crate::fetcher::data_request::{DataSource, FetcherDataRequest, RedditFeedKind};
 use crate::fetcher::reddit::request::feed_sorting::{FeedSorting, FeedSortingTime};
 use crate::validation::validation_error::ValidationError;
-use axum::async_trait;
 use futures_util::future::join_all;
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
@@ -57,12 +56,11 @@ fn feed_sorting_from_snake_case(kind: &str, time: Option<&str>) -> Result<FeedSo
     }
 }
 
-#[async_trait]
 impl DbStoredDependentlyInner for FetcherDataRequest {
     async fn inner_save(
         &self,
         parent_id: &str,
-        tx: &mut Transaction<Postgres>,
+        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<Uuid, DbError> {
         let data_request_uuid = sqlx::query!(
             r#"
@@ -90,7 +88,6 @@ impl DbStoredDependentlyInner for FetcherDataRequest {
     }
 }
 
-#[async_trait]
 impl FromDb for FetcherDataRequest {
     type DbModel = DbDataRequest;
     async fn from_db_model(model: Self::DbModel, pool: &PgPool) -> Result<Self, DbError> {

--- a/backend/src/db/impls/data_source.rs
+++ b/backend/src/db/impls/data_source.rs
@@ -4,16 +4,14 @@ use crate::db::from_db::FromDb;
 use crate::db::model::DbDataSource;
 use crate::fetcher::data_request::DataSource;
 use crate::validation::validation_error::ValidationError;
-use axum::async_trait;
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
-#[async_trait]
 impl DbStoredDependentlyInner for DataSource {
     async fn inner_save(
         &self,
         parent_id: &str,
-        tx: &mut Transaction<Postgres>,
+        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<Uuid, DbError> {
         let parent_id = Uuid::parse_str(parent_id).map_err(|_| {
             DbError::from(ValidationError::Invalid(
@@ -40,7 +38,6 @@ impl DbStoredDependentlyInner for DataSource {
     }
 }
 
-#[async_trait]
 impl FromDb for DataSource {
     type DbModel = DbDataSource;
     async fn from_db_model(model: Self::DbModel, _pool: &PgPool) -> Result<Self, DbError> {

--- a/backend/src/db/impls/nlp_analysis.rs
+++ b/backend/src/db/impls/nlp_analysis.rs
@@ -4,16 +4,14 @@ use crate::db::from_db::FromDb;
 use crate::db::model::DbNlpAnalysis;
 use crate::nlp::analysis::NlpAnalysisKind;
 use crate::nlp::nlp_response::NlpAnalysis;
-use axum::async_trait;
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
-#[async_trait]
 impl DbStoredDependentlyInner for NlpAnalysis {
     async fn inner_save(
         &self,
         parent_id: &str,
-        tx: &mut Transaction<Postgres>,
+        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<Uuid, DbError> {
         let analysis_id = sqlx::query!(
             r#"
@@ -34,10 +32,9 @@ impl DbStoredDependentlyInner for NlpAnalysis {
     }
 }
 
-#[async_trait]
 impl FromDb for NlpAnalysis {
     type DbModel = DbNlpAnalysis;
-    async fn from_db_model(model: Self::DbModel, pool: &PgPool) -> Result<Self, DbError> {
+    async fn from_db_model(model: Self::DbModel, _pool: &PgPool) -> Result<Self, DbError> {
         Ok(NlpAnalysis {
             kind: NlpAnalysisKind::from_snake_case(&model.kind).unwrap(),
             results: serde_json::from_value(model.analysis.clone()).unwrap(),

--- a/backend/src/db/impls/report.rs
+++ b/backend/src/db/impls/report.rs
@@ -7,13 +7,11 @@ use crate::fetcher::data_request::FetcherDataRequest;
 use crate::nlp::nlp_response::NlpAnalysis;
 use crate::report::report::Report;
 use crate::report::report_status::ReportStatus;
-use axum::async_trait;
 use sqlx::{PgPool, Postgres, Transaction};
 use std::collections::HashMap;
 
-#[async_trait]
 impl DbStoredInner for Report {
-    async fn inner_save(&self, tx: &mut Transaction<Postgres>) -> Result<(), DbError> {
+    async fn inner_save(&self, tx: &mut Transaction<'_, Postgres>) -> Result<(), DbError> {
         let user_id = sqlx::query!(
             r#"
             SELECT google_id as "id: String" FROM users WHERE google_id = $1
@@ -68,7 +66,7 @@ impl DbStoredInner for Report {
     ///
     /// This method updates the report's title, description, public status, and status.
     /// The metadata and analyses map are not updated, as they are not expected to change.
-    async fn inner_update(&self, tx: &mut Transaction<Postgres>) -> Result<(), DbError> {
+    async fn inner_update(&self, tx: &mut Transaction<'_, Postgres>) -> Result<(), DbError> {
         for (_, analysis) in &self.analyses {
             analysis.inner_save(self.id.as_str(), tx).await?;
         }
@@ -95,7 +93,7 @@ impl DbStoredInner for Report {
         .await?;
         Ok(())
     }
-    async fn inner_delete(&self, tx: &mut Transaction<Postgres>) -> Result<(), DbError> {
+    async fn inner_delete(&self, tx: &mut Transaction<'_, Postgres>) -> Result<(), DbError> {
         sqlx::query!(
             r#"
             DELETE FROM reports WHERE id = $1
@@ -142,12 +140,14 @@ impl DbStoredInner for Report {
         Ok(())
     }
 
-    async fn inner_get_all(pagination: DbPagination, pool: &PgPool) -> Result<Vec<Self>, DbError> {
+    async fn inner_get_all(
+        _pagination: DbPagination,
+        _pool: &PgPool,
+    ) -> Result<Vec<Self>, DbError> {
         unimplemented!()
     }
 }
 
-#[async_trait]
 impl FromDb for Report {
     type DbModel = DbReport;
     async fn from_db_model(model: Self::DbModel, pool: &PgPool) -> Result<Self, DbError> {

--- a/backend/src/db/impls/report_query.rs
+++ b/backend/src/db/impls/report_query.rs
@@ -8,7 +8,6 @@ use crate::fetcher::data_request::RedditFeedKind;
 use crate::nlp::analysis::NlpAnalysisKind;
 use crate::report::report::Report;
 use crate::util::get_utc_timestamp;
-use axum::async_trait;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -208,7 +207,6 @@ pub struct ReportQueryResult {
 /// Repository trait for reports.
 ///
 /// Specifies methods for fetching reports from the database.
-#[async_trait]
 pub trait ReportRepository: Sized {
     async fn get_by_query(
         query: ReportQuery,
@@ -217,7 +215,6 @@ pub trait ReportRepository: Sized {
     ) -> Result<ReportQueryResult, DbError>;
 }
 
-#[async_trait]
 impl ReportRepository for Report {
     /// Fetches reports from the database based on the query and pagination.
     async fn get_by_query(

--- a/backend/src/db/impls/user.rs
+++ b/backend/src/db/impls/user.rs
@@ -2,12 +2,10 @@ use crate::auth::user::User;
 use crate::db::db_error::DbError;
 use crate::db::db_stored::DbStoredInner;
 use crate::db::pagination::DbPagination;
-use axum::async_trait;
 use sqlx::{PgPool, Postgres, Transaction};
 
-#[async_trait]
 impl DbStoredInner for User {
-    async fn inner_save(&self, tx: &mut Transaction<Postgres>) -> Result<(), DbError> {
+    async fn inner_save(&self, tx: &mut Transaction<'_, Postgres>) -> Result<(), DbError> {
         sqlx::query!(
             r#"
             INSERT INTO users (
@@ -29,10 +27,10 @@ impl DbStoredInner for User {
         .await?;
         Ok(())
     }
-    async fn inner_update(&self, tx: &mut Transaction<Postgres>) -> Result<(), DbError> {
+    async fn inner_update(&self, _tx: &mut Transaction<'_, Postgres>) -> Result<(), DbError> {
         unimplemented!()
     }
-    async fn inner_delete(&self, tx: &mut Transaction<Postgres>) -> Result<(), DbError> {
+    async fn inner_delete(&self, tx: &mut Transaction<'_, Postgres>) -> Result<(), DbError> {
         // Delete all reports of that user
         sqlx::query!(
             r#"
@@ -82,7 +80,10 @@ impl DbStoredInner for User {
         Ok(())
     }
 
-    async fn inner_get_all(pagination: DbPagination, pool: &PgPool) -> Result<Vec<Self>, DbError> {
+    async fn inner_get_all(
+        _pagination: DbPagination,
+        _pool: &PgPool,
+    ) -> Result<Vec<Self>, DbError> {
         unimplemented!()
     }
 }

--- a/backend/src/report/report_request.rs
+++ b/backend/src/report/report_request.rs
@@ -2,7 +2,6 @@ use crate::fetcher::data_request::FetcherDataRequest;
 use crate::nlp::nlp_request::NlpRequest;
 use crate::validation::validated::Validated;
 use crate::validation::validation_error::ValidationError;
-use axum::async_trait;
 use axum::body::Bytes;
 use axum::extract::{FromRequest, Request};
 use http::StatusCode;
@@ -18,7 +17,6 @@ pub struct ReportRequest {
     pub nlp_request: NlpRequest,
 }
 
-#[async_trait]
 impl<S> FromRequest<S> for ReportRequest
 where
     S: Send + Sync,

--- a/backend/src/websocket/socket_handler.rs
+++ b/backend/src/websocket/socket_handler.rs
@@ -1,7 +1,7 @@
 use crate::auth::user::GoogleId;
 use crate::websocket;
 use crate::websocket::{ClientMessage, SystemMessage};
-use axum::extract::ws::{Message, WebSocket};
+use axum::extract::ws::{Message, Utf8Bytes, WebSocket};
 use futures_util::StreamExt;
 use serde_json::json;
 use std::net::SocketAddr;
@@ -78,7 +78,7 @@ pub async fn handle_socket(
             service_msg_res = service_to_client_rx.recv() => {
                 if let Some(msg) = service_msg_res {
                     log::debug!("Received message from the main service: {:?}", msg);
-                    let _ = socket.send(Message::Text(json!(msg).to_string())).await;
+                    let _ = socket.send(Message::Text(Utf8Bytes::from(json!(msg).to_string()))).await;
                 } else {
                     log::error!("WS Service task has exited or closed the mpsc channel");
                     return;


### PR DESCRIPTION
This pull request includes several updates to dependencies and refactors to remove the `async_trait` dependency across multiple files. The most important changes include updating dependencies in `Cargo.toml`, removing `async_trait` from various traits and implementations, and modifying the `handle_socket` function to use `Utf8Bytes`.

Dependency updates:

* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L11-R27): Updated versions for `axum`, `tower-http`, `utoipa`, `utoipa-swagger-ui`, `derive-getters`, `thiserror`, `sqlx`, and `axum-extra`. [[1]](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L11-R27) [[2]](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L38-R38)

Refactoring to remove `async_trait`:

* [`backend/src/api/about/subreddit.rs`](diffhunk://#diff-1d80fb23f025570bf3ddd2105042b2075815f928aaf04943c9f54fbe02b2f443L8): Removed `async_trait` from the `subreddit_about` function.
* [`backend/src/api/about/user.rs`](diffhunk://#diff-8c516426fd986f09cee7e542eab8ae870de06f52a7acefeea53420ecb488d492L8): Removed `async_trait` from the `user_about` function.
* [`backend/src/auth/google.rs`](diffhunk://#diff-e0b97bcc4e11cb355125dd3017ba8d9dcb99266737b83723005cef3b83210150L5-R12): Removed `async_trait` from `JwtUserInfo` implementation and added `Future` import. [[1]](diffhunk://#diff-e0b97bcc4e11cb355125dd3017ba8d9dcb99266737b83723005cef3b83210150L5-R12) [[2]](diffhunk://#diff-e0b97bcc4e11cb355125dd3017ba8d9dcb99266737b83723005cef3b83210150L33-R33)
* [`backend/src/db/db_stored.rs`](diffhunk://#diff-ebadc158a666412ab23df1698912f9218f9270f9fb66c77dab82402078aca5dcL4): Removed `async_trait` from `DbStoredInner` and `DbStoredDependentlyInner` traits. [[1]](diffhunk://#diff-ebadc158a666412ab23df1698912f9218f9270f9fb66c77dab82402078aca5dcL4) [[2]](diffhunk://#diff-ebadc158a666412ab23df1698912f9218f9270f9fb66c77dab82402078aca5dcL58) [[3]](diffhunk://#diff-ebadc158a666412ab23df1698912f9218f9270f9fb66c77dab82402078aca5dcL77)
* [`backend/src/db/from_db.rs`](diffhunk://#diff-f85cf353b8dd83b1fdbb64889ced84fead4cac9e6438fdf6c4f80b67a6f38fe2L2-L6): Removed `async_trait` from `FromDb` trait.
* [`backend/src/db/impls/data_request.rs`](diffhunk://#diff-bf7220597a770e3967600634baa1f3770e858c3059a39179cc70c932588348feL8): Removed `async_trait` from `DbStoredDependentlyInner` and `FromDb` implementations for `FetcherDataRequest`. [[1]](diffhunk://#diff-bf7220597a770e3967600634baa1f3770e858c3059a39179cc70c932588348feL8) [[2]](diffhunk://#diff-bf7220597a770e3967600634baa1f3770e858c3059a39179cc70c932588348feL60-R63) [[3]](diffhunk://#diff-bf7220597a770e3967600634baa1f3770e858c3059a39179cc70c932588348feL93)
* [`backend/src/db/impls/data_source.rs`](diffhunk://#diff-33521b6cecb402fe88c1b0ad870462f99d32b69fdd20c34e5b9cba35f77dfa00L7-R14): Removed `async_trait` from `DbStoredDependentlyInner` and `FromDb` implementations for `DataSource`. [[1]](diffhunk://#diff-33521b6cecb402fe88c1b0ad870462f99d32b69fdd20c34e5b9cba35f77dfa00L7-R14) [[2]](diffhunk://#diff-33521b6cecb402fe88c1b0ad870462f99d32b69fdd20c34e5b9cba35f77dfa00L43)
* [`backend/src/db/impls/nlp_analysis.rs`](diffhunk://#diff-118203f295aef07a567fc7c9906ee1ef6af9c842c6465295f8a8881ce681f3cdL7-R14): Removed `async_trait` from `DbStoredDependentlyInner` and `FromDb` implementations for `NlpAnalysis`. [[1]](diffhunk://#diff-118203f295aef07a567fc7c9906ee1ef6af9c842c6465295f8a8881ce681f3cdL7-R14) [[2]](diffhunk://#diff-118203f295aef07a567fc7c9906ee1ef6af9c842c6465295f8a8881ce681f3cdL37-R37)
* [`backend/src/db/impls/report.rs`](diffhunk://#diff-a461a80bc1fb9ffac54bc92f0bb7c21022b20416995c37de326f13468da2ca10L10-R14): Removed `async_trait` from `DbStoredInner` and `FromDb` implementations for `Report`. [[1]](diffhunk://#diff-a461a80bc1fb9ffac54bc92f0bb7c21022b20416995c37de326f13468da2ca10L10-R14) [[2]](diffhunk://#diff-a461a80bc1fb9ffac54bc92f0bb7c21022b20416995c37de326f13468da2ca10L71-R69) [[3]](diffhunk://#diff-a461a80bc1fb9ffac54bc92f0bb7c21022b20416995c37de326f13468da2ca10L98-R96) [[4]](diffhunk://#diff-a461a80bc1fb9ffac54bc92f0bb7c21022b20416995c37de326f13468da2ca10L145-L150)
* [`backend/src/db/impls/report_query.rs`](diffhunk://#diff-f1c9873212e5d316bca382249795a72a2c052a662836e3363af55317498f50b2L11): Removed `async_trait` from `ReportRepository` trait and its implementation for `Report`. [[1]](diffhunk://#diff-f1c9873212e5d316bca382249795a72a2c052a662836e3363af55317498f50b2L11) [[2]](diffhunk://#diff-f1c9873212e5d316bca382249795a72a2c052a662836e3363af55317498f50b2L211) [[3]](diffhunk://#diff-f1c9873212e5d316bca382249795a72a2c052a662836e3363af55317498f50b2L220)
* [`backend/src/db/impls/user.rs`](diffhunk://#diff-cf3e8beeea04b135277fdc18251e489247d0ff285ac64d81f9f1b5a6058a64e0L5-R8): Removed `async_trait` from `DbStoredInner` implementation for `User`. [[1]](diffhunk://#diff-cf3e8beeea04b135277fdc18251e489247d0ff285ac64d81f9f1b5a6058a64e0L5-R8) [[2]](diffhunk://#diff-cf3e8beeea04b135277fdc18251e489247d0ff285ac64d81f9f1b5a6058a64e0L32-R33) [[3]](diffhunk://#diff-cf3e8beeea04b135277fdc18251e489247d0ff285ac64d81f9f1b5a6058a64e0L85-R86)
* [`backend/src/report/report_request.rs`](diffhunk://#diff-fcd929ac26cee237d28bd3de252b2eb36bfd5d839d83517755a3a252165f5ceaL5): Removed `async_trait` from `FromRequest` implementation for `ReportRequest`. [[1]](diffhunk://#diff-fcd929ac26cee237d28bd3de252b2eb36bfd5d839d83517755a3a252165f5ceaL5) [[2]](diffhunk://#diff-fcd929ac26cee237d28bd3de252b2eb36bfd5d839d83517755a3a252165f5ceaL21)

WebSocket handling:

* [`backend/src/websocket/socket_handler.rs`](diffhunk://#diff-f7f743af0f995f1514e734754e3ca1834054ae1edcdda962c7d3342c5f446245L4-R4): Modified `handle_socket` function to use `Utf8Bytes` for sending messages. [[1]](diffhunk://#diff-f7f743af0f995f1514e734754e3ca1834054ae1edcdda962c7d3342c5f446245L4-R4) [[2]](diffhunk://#diff-f7f743af0f995f1514e734754e3ca1834054ae1edcdda962c7d3342c5f446245L81-R81)