### PR TITLE
319: Delete reports

### DIFF
--- a/backend/.sqlx/query-00abef5b00e3b0c6e4cce14c0a0f3ec4ce91d2c09aa39648363f43bd9af77db3.json
+++ b/backend/.sqlx/query-00abef5b00e3b0c6e4cce14c0a0f3ec4ce91d2c09aa39648363f43bd9af77db3.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM reports\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "00abef5b00e3b0c6e4cce14c0a0f3ec4ce91d2c09aa39648363f43bd9af77db3"
+}

--- a/backend/.sqlx/query-1949d0185bebedc97b5b0e0c197fb132e81274b4c8d7bad7129023dcd53b6101.json
+++ b/backend/.sqlx/query-1949d0185bebedc97b5b0e0c197fb132e81274b4c8d7bad7129023dcd53b6101.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT user_id\n            FROM reports\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1949d0185bebedc97b5b0e0c197fb132e81274b4c8d7bad7129023dcd53b6101"
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,5 +1,5 @@
 use crate::AppState;
-use axum::routing::post;
+use axum::routing::{delete, post};
 use axum::{routing::get, Router};
 
 pub mod about;
@@ -14,6 +14,7 @@ pub fn router() -> Router<AppState> {
     Router::<AppState>::new()
         .route("/report", post(report::generate::generate_report_handler))
         .route("/report", get(report::get::get_reports))
+        .route("/report/{id}", delete(report::delete::delete_report))
         .route("/about/subreddit", get(about::subreddit::subreddit_about))
         .route("/about/user", get(about::user::user_about))
         .route("/user", get(user::get_user))

--- a/backend/src/api/report/delete.rs
+++ b/backend/src/api/report/delete.rs
@@ -1,16 +1,10 @@
 use crate::app_error::AppError;
+use crate::auth::google::JwtUserInfo;
 use crate::auth::user::GoogleId;
 use crate::db::impls::report_query::ReportRepository;
 use crate::report::report::{Report, ReportId};
 use crate::AppState;
 use axum::extract::{Path, State};
-use axum::Json;
-use serde_with::serde_derive::Serialize;
-
-#[derive(Serialize)]
-pub struct DeleteReportResponse {
-    deleted: u64,
-}
 
 /// Deletes a report by ID.
 ///
@@ -18,14 +12,29 @@ pub struct DeleteReportResponse {
 pub async fn delete_report(
     State(state): State<AppState>,
     Path(id): Path<ReportId>,
-    user_id: GoogleId,
-) -> Result<Json<DeleteReportResponse>, AppError> {
+    jwt_user_info: JwtUserInfo,
+) -> Result<(), AppError> {
+    let user_id = jwt_user_info.id;
     match Report::owner_id_by_id(&id, &state.db).await? {
         Some(owner_id) if owner_id == user_id => {
             let deleted = Report::delete_by_id(&id, &state.db).await?;
-            Ok(Json(DeleteReportResponse { deleted }))
+            if deleted == 0 {
+                return Err(AppError::not_found());
+            }
+            log::info!("Report {} deleted by user {}", id, user_id);
+            Ok(())
         }
-        Some(_) => Err(AppError::unauthorized()),
-        None => Err(AppError::not_found()),
+        Some(_) => {
+            log::warn!(
+                "User {} tried to delete report {} but is not the owner",
+                user_id,
+                id
+            );
+            Err(AppError::unauthorized())
+        }
+        None => {
+            log::info!("Report {} not found", id);
+            Err(AppError::not_found())
+        }
     }
 }

--- a/backend/src/api/report/delete.rs
+++ b/backend/src/api/report/delete.rs
@@ -1,0 +1,31 @@
+use crate::app_error::AppError;
+use crate::auth::user::GoogleId;
+use crate::db::impls::report_query::ReportRepository;
+use crate::report::report::{Report, ReportId};
+use crate::AppState;
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_with::serde_derive::Serialize;
+
+#[derive(Serialize)]
+pub struct DeleteReportResponse {
+    deleted: u64,
+}
+
+/// Deletes a report by ID.
+///
+/// Only the owner of the report can delete it.
+pub async fn delete_report(
+    State(state): State<AppState>,
+    Path(id): Path<ReportId>,
+    user_id: GoogleId,
+) -> Result<Json<DeleteReportResponse>, AppError> {
+    match Report::owner_id_by_id(&id, &state.db).await? {
+        Some(owner_id) if owner_id == user_id => {
+            let deleted = Report::delete_by_id(&id, &state.db).await?;
+            Ok(Json(DeleteReportResponse { deleted }))
+        }
+        Some(_) => Err(AppError::unauthorized()),
+        None => Err(AppError::not_found()),
+    }
+}

--- a/backend/src/api/report/mod.rs
+++ b/backend/src/api/report/mod.rs
@@ -1,3 +1,4 @@
+pub mod delete;
 pub mod generate;
 pub mod get;
 pub mod report_ack;

--- a/backend/src/app_error.rs
+++ b/backend/src/app_error.rs
@@ -37,6 +37,11 @@ impl AppError {
     pub fn not_found() -> Self {
         AppError::new(StatusCode::NOT_FOUND, "Resource not found")
     }
+
+    /// Shorthand for creating a 401 response.
+    pub fn unauthorized() -> Self {
+        AppError::new(StatusCode::UNAUTHORIZED, "Unauthorized")
+    }
 }
 
 impl IntoResponse for AppError {

--- a/backend/src/db/db_error.rs
+++ b/backend/src/db/db_error.rs
@@ -6,5 +6,6 @@ use thiserror::Error;
 pub enum DbError {
     SqlxError(#[from] sqlx::Error),
     ValidationError(#[from] ValidationError),
+    SerdeJsonError(#[from] serde_json::Error),
     NotFound(String),
 }

--- a/backend/src/db/impls/nlp_analysis.rs
+++ b/backend/src/db/impls/nlp_analysis.rs
@@ -4,6 +4,7 @@ use crate::db::from_db::FromDb;
 use crate::db::model::DbNlpAnalysis;
 use crate::nlp::analysis::NlpAnalysisKind;
 use crate::nlp::nlp_response::NlpAnalysis;
+use log_derive::logfn;
 use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
@@ -34,10 +35,14 @@ impl DbStoredDependentlyInner for NlpAnalysis {
 
 impl FromDb for NlpAnalysis {
     type DbModel = DbNlpAnalysis;
+    #[logfn(
+        err = "ERROR",
+        fmt = "Failed to convert NlpAnalysis from DbModel: {0:?}"
+    )]
     async fn from_db_model(model: Self::DbModel, _pool: &PgPool) -> Result<Self, DbError> {
         Ok(NlpAnalysis {
             kind: NlpAnalysisKind::from_snake_case(&model.kind).unwrap(),
-            results: serde_json::from_value(model.analysis.clone()).unwrap(),
+            results: serde_json::from_value(model.analysis.clone())?,
             generated_in: model.generated_in,
         })
     }

--- a/backend/src/db/impls/report_query.rs
+++ b/backend/src/db/impls/report_query.rs
@@ -6,7 +6,7 @@ use crate::db::model::DbReport;
 use crate::db::pagination::DbPagination;
 use crate::fetcher::data_request::RedditFeedKind;
 use crate::nlp::analysis::NlpAnalysisKind;
-use crate::report::report::Report;
+use crate::report::report::{Report, ReportId};
 use crate::util::get_utc_timestamp;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -213,6 +213,8 @@ pub trait ReportRepository: Sized {
         requesting_user_id: GoogleId,
         db: &DbClient,
     ) -> Result<ReportQueryResult, DbError>;
+    async fn delete_by_id(id: &ReportId, db: &DbClient) -> Result<u64, DbError>;
+    async fn owner_id_by_id(id: &ReportId, db: &DbClient) -> Result<Option<GoogleId>, DbError>;
 }
 
 impl ReportRepository for Report {
@@ -326,8 +328,8 @@ impl ReportRepository for Report {
             limit,
             offset
         )
-        .fetch_all(db.raw_db())
-        .await?;
+            .fetch_all(db.raw_db())
+            .await?;
 
         let total_reports = db_reports
             .first()
@@ -357,6 +359,36 @@ impl ReportRepository for Report {
             reports,
             total_pages,
         })
+    }
+
+    async fn delete_by_id(id: &ReportId, db: &DbClient) -> Result<u64, DbError> {
+        let deleted = sqlx::query!(
+            r#"
+            DELETE FROM reports
+            WHERE id = $1
+            "#,
+            id
+        )
+        .execute(db.raw_db())
+        .await?;
+
+        Ok(deleted.rows_affected())
+    }
+
+    async fn owner_id_by_id(id: &ReportId, db: &DbClient) -> Result<Option<GoogleId>, DbError> {
+        let owner_id = sqlx::query!(
+            r#"
+            SELECT user_id
+            FROM reports
+            WHERE id = $1
+            "#,
+            id
+        )
+        .fetch_optional(db.raw_db())
+        .await?
+        .map(|r| r.user_id);
+
+        Ok(owner_id)
     }
 }
 

--- a/backend/src/db/impls/report_query.rs
+++ b/backend/src/db/impls/report_query.rs
@@ -989,4 +989,44 @@ mod tests {
             assert!(result.reports[i].created_at < result.reports[i + 1].created_at);
         }
     }
+
+    #[sqlx::test]
+    async fn test_delete_report_by_id(pool: PgPool) {
+        let db = DbClient::new(pool);
+        let ((r1, _, _, _), _) = setup(&db).await;
+
+        let deleted = Report::delete_by_id(&r1.id, &db).await.unwrap();
+
+        assert_eq!(deleted, 1);
+    }
+
+    #[sqlx::test]
+    async fn test_delete_report_by_id_not_found(pool: PgPool) {
+        let db = DbClient::new(pool);
+        let (_, (u1, _, _)) = setup(&db).await;
+
+        let deleted = Report::delete_by_id(&ReportId::new(), &db).await.unwrap();
+
+        assert_eq!(deleted, 0);
+    }
+
+    #[sqlx::test]
+    async fn test_owner_id_by_id(pool: PgPool) {
+        let db = DbClient::new(pool);
+        let ((r1, _, _, _), (u1, _, _)) = setup(&db).await;
+
+        let owner_id = Report::owner_id_by_id(&r1.id, &db).await.unwrap();
+
+        assert_eq!(owner_id, Some(u1.id));
+    }
+
+    #[sqlx::test]
+    async fn test_owner_id_by_id_not_found(pool: PgPool) {
+        let db = DbClient::new(pool);
+        let (_, (u1, _, _)) = setup(&db).await;
+
+        let owner_id = Report::owner_id_by_id(&ReportId::new(), &db).await.unwrap();
+
+        assert_eq!(owner_id, None);
+    }
 }

--- a/frontend/src/rmoods/client/RMoodsClient.ts
+++ b/frontend/src/rmoods/client/RMoodsClient.ts
@@ -66,4 +66,14 @@ export class RMoodsClient {
       return res.json();
     });
   }
+
+  static async deleteReportById(reportId: string): Promise<void> {
+    return await authFetch(`/report/${reportId}`, {
+      method: 'DELETE',
+    }).then((res) => {
+      if (!res.ok) {
+        throw new Error('Failed to delete report');
+      }
+    });
+  }
 }

--- a/frontend/src/rmoods/types.ts
+++ b/frontend/src/rmoods/types.ts
@@ -130,3 +130,7 @@ interface ReportDataRequest {
   size: number;
   sortBy: SortBy;
 }
+
+interface ReportDeleteResponse {
+  deleted: boolean;
+}

--- a/frontend/src/routes/user/reports/page.tsx
+++ b/frontend/src/routes/user/reports/page.tsx
@@ -2,6 +2,7 @@ import {
   ActionIcon,
   Anchor,
   Box,
+  Button,
   Center,
   Flex,
   Group,
@@ -32,11 +33,13 @@ import {
   IconArrowNarrowDown,
   IconArrowNarrowUp,
   IconCheck,
+  IconTrash,
   IconX,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { addDays } from 'date-fns';
-import { truncateText, extractAnalysisKinds } from '../../../utility/util.ts';
+import { extractAnalysisKinds, truncateText } from '../../../utility/util.ts';
+import { notifications } from '@mantine/notifications';
 
 export type MyReportsPageReportQuery = Omit<
   ReportQuery,
@@ -294,6 +297,7 @@ const UserReportsPage = () => {
                 </Flex>
               </Table.Th>
               <Table.Th>Status</Table.Th>
+              <Table.Th></Table.Th>
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
@@ -304,9 +308,16 @@ const UserReportsPage = () => {
                     {report.title}
                   </Anchor>
                 </Table.Td>
-                <Table.Td>{extractAnalysisKinds(report.analyses).join(', ')}</Table.Td>
                 <Table.Td>
-                  <Tooltip label={report.description} withArrow multiline w={300}>
+                  {extractAnalysisKinds(report.analyses).join(', ')}
+                </Table.Td>
+                <Table.Td>
+                  <Tooltip
+                    label={report.description}
+                    withArrow
+                    multiline
+                    w={300}
+                  >
                     <Box>{truncateText(report.description, 45)}</Box>
                   </Tooltip>
                 </Table.Td>
@@ -315,6 +326,24 @@ const UserReportsPage = () => {
                 </Table.Td>
                 <Table.Td>
                   <Center>{renderStatus(report.status)}</Center>
+                </Table.Td>
+                <Table.Td>
+                  <Center>
+                    <Button color={'red'}>
+                      <IconTrash
+                        onClick={async () => {
+                          await RMoodsClient.deleteReportById(report.id);
+                          setReports(reports.filter((r) => r.id !== report.id));
+                          notifications.show({
+                            title: 'Report deleted',
+                            message: 'The report has been deleted',
+                          });
+                        }}
+                        size={24}
+                        color={'white'}
+                      />
+                    </Button>
+                  </Center>
                 </Table.Td>
               </Table.Tr>
             ))}


### PR DESCRIPTION
This pull request introduces a new feature to delete reports and includes several related changes across the backend and frontend. The most important changes include adding the delete report functionality in the backend, updating the frontend to support report deletion, and enhancing error handling.

Backend changes:

* Added a new route to delete reports in `backend/src/api/mod.rs` and implemented the `delete_report` function in `backend/src/api/report/delete.rs`. [[1]](diffhunk://#diff-7b86efc9d28a79e49f7096f8b1c301256e5705dcc5ca1f3bc78dd086d10389f0R17) [[2]](diffhunk://#diff-4ce88ac4bb9a309144d759f5f7deb4e21c42782787c1f67da9ca7c7e0c0f7b2eR1-R40)
* Updated the `ReportRepository` trait and its implementation to include methods for deleting a report by ID and fetching the owner ID of a report in `backend/src/db/impls/report_query.rs`. [[1]](diffhunk://#diff-f1c9873212e5d316bca382249795a72a2c052a662836e3363af55317498f50b2R216-R217) [[2]](diffhunk://#diff-f1c9873212e5d316bca382249795a72a2c052a662836e3363af55317498f50b2R363-R392)
* Added tests for the new methods in `backend/src/db/impls/report_query.rs`.

Frontend changes:

* Added a `deleteReportById` method in `frontend/src/rmoods/client/RMoodsClient.ts` to handle report deletion requests.
* Updated the user reports page to include a delete button for each report, which calls the delete method and updates the UI accordingly in `frontend/src/routes/user/reports/page.tsx`. [[1]](diffhunk://#diff-917537c63b3b2894ec6c143ddccc6308fe1ee6e4f2cfbda3b1bfc592cf1b3a15R300) [[2]](diffhunk://#diff-917537c63b3b2894ec6c143ddccc6308fe1ee6e4f2cfbda3b1bfc592cf1b3a15R330-R347)

Error handling improvements:

* Added a new `unauthorized` method to the `AppError` struct in `backend/src/app_error.rs` to handle unauthorized access attempts.
* Enhanced error logging in `backend/src/db/impls/nlp_analysis.rs` by adding a `logfn` attribute to the `from_db_model` method.