### PR TITLE
338: Add more routes to visual regression tests

### DIFF
--- a/frontend/cypress/visual/VisualRegression.cy.ts
+++ b/frontend/cypress/visual/VisualRegression.cy.ts
@@ -8,6 +8,10 @@ describe('Visual Regression tests', () => {
     cy.visitPageAndScreenshotIt('about/faq');
   });
 
+  it('Creates "/about/thesis" snapshot', () => {
+    cy.visitPageAndScreenshotIt('about/thesis');
+  });
+
   it('Creates "/dashboard" snapshot', () => {
     cy.visitPageAndScreenshotIt('dashboard');
   });
@@ -26,5 +30,25 @@ describe('Visual Regression tests', () => {
 
   it('Creates "/user" snapshot', () => {
     cy.visitPageAndScreenshotIt('user');
+  });
+
+  it('Creates "/user/reports" snapshot', () => {
+    cy.visitPageAndScreenshotIt('user/reports');
+  });
+
+  it('Creates "/browse/reports" snapshot', () => {
+    cy.visitPageAndScreenshotIt('browse/reports');
+  });
+
+  it('Creates "/browse/users" snapshot', () => {
+    cy.visitPageAndScreenshotIt('browse/users');
+  });
+
+  it('Creates "/sandbox" snapshot', () => {
+    cy.visitPageAndScreenshotIt('sandbox');
+  });
+
+  it('Creates "/releases" snapshot', () => {
+    cy.visitPageAndScreenshotIt('releases');
   });
 });


### PR DESCRIPTION
This pull request includes several new visual regression tests in the `frontend/cypress/visual/VisualRegression.cy.ts` file. The new tests cover additional pages to ensure that visual consistency is maintained across the application.

New visual regression tests added:

* Added snapshot test for the `/about/thesis` page.
* Added snapshot test for the `/user/reports` page.
* Added snapshot test for the `/browse/reports` page.
* Added snapshot test for the `/browse/users` page.
* Added snapshot test for the `/sandbox` page.
* Added snapshot test for the `/releases` page.